### PR TITLE
Bypass SENTRY_ENVIRONMENT variable in order to send relevant value to Sentry.

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.3.2
+version: 1.3.3
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 
@@ -60,6 +60,7 @@ Kubernetes: `^1.18.x-x`
 | settings.authBackend | string | `"link"` | auth method used (console|link|postgres) |
 | settings.authEndpoint | string | `""` | auth endpoint, e.g. "http://console.neon/authenticate_proxy_request/" |
 | settings.domain | string | `""` | domain used in TLS cert for client postgres connections |
+| settings.sentryEnvironment | string | `"development"` | "development" or "production". It will be visible in sentry in order to filter issues |
 | settings.sentryUrl | string | `""` | url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in neon-proxy |
 | settings.uri | string | `""` |  |
 | tolerations | list | `[]` | Tolerations for pod assignment. |

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
             - name: SENTRY_DSN
               value: {{ . }}
             {{- end }}
+            {{- with .Values.settings.sentryEnvironment }}
+              - name: SENTRY_ENVIRONMENT
+                value: {{ . }}
+            {{- end }}
           {{- end }}
           {{- if .Values.settings.domain }}
           volumeMounts:

--- a/charts/neon-proxy/values.yaml
+++ b/charts/neon-proxy/values.yaml
@@ -32,6 +32,8 @@ settings:
   domain: ""
   # settings.sentryUrl -- url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in neon-proxy
   sentryUrl: ""
+  # settings.sentryEnvironment -- "development" or "production". It will be visible in sentry in order to filter issues
+  sentryEnvironment: "development"
 
 serviceAccount:
   # serviceAccount.create - Specifies whether a service account should be created

--- a/charts/neon-storage-broker/Chart.yaml
+++ b/charts/neon-storage-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-broker
 description: Neon storage broker
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-broker/README.md
+++ b/charts/neon-storage-broker/README.md
@@ -1,6 +1,6 @@
 # neon-storage-broker
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage broker
 
@@ -60,6 +60,7 @@ Kubernetes: `^1.18.x-x`
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| settings.sentryEnvironment | string | `"development"` | "development" or "production". It will be visible in sentry in order to filter issues |
 | settings.sentryUrl | string | `""` | url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in storage-broker |
 | tolerations | list | `[]` | Tolerations for pod assignment. |
 

--- a/charts/neon-storage-broker/templates/deployment.yaml
+++ b/charts/neon-storage-broker/templates/deployment.yaml
@@ -50,6 +50,10 @@ spec:
             - name: SENTRY_DSN
               value: {{ . }}
             {{- end }}
+            {{- with .Values.settings.sentryEnvironment }}
+            - name: SENTRY_ENVIRONMENT
+              value: {{ . }}
+            {{- end }}
           {{- end }}
           ports:
             - name: broker

--- a/charts/neon-storage-broker/values.yaml
+++ b/charts/neon-storage-broker/values.yaml
@@ -22,6 +22,8 @@ fullnameOverride: ""
 settings:
   # settings.sentryUrl -- url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in storage-broker
   sentryUrl: ""
+  # settings.sentryEnvironment -- "development" or "production". It will be visible in sentry in order to filter issues
+  sentryEnvironment: "development"
 
 serviceAccount:
   # serviceAccount.create - Specifies whether a service account should be created


### PR DESCRIPTION
Neon-proxy and neon-broker-storage charts were affected.