### PR TITLE
Support deployment strategy and grace time customization

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.5.2
+version: 1.6.2
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 
@@ -28,6 +28,8 @@ Kubernetes: `^1.18.x-x`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for pod assignment |
+| containerLifecycle | object | `{}` | container lifecycle hooks specification for neon-proxy container |
+| deploymentStrategy | object | `{"type":"Recreate"}` | strategy override for deployment |
 | exposedService.annotations | object | `{}` | Annotations to add to the exposed service |
 | exposedService.httpsPort | int | `nil` | Exposed Service https port. If null, https server will not be exposed. |
 | exposedService.port | int | `5432` | Exposed Service proxy port |
@@ -68,6 +70,7 @@ Kubernetes: `^1.18.x-x`
 | settings.sentryUrl | string | `""` | url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in neon-proxy |
 | settings.uri | string | `""` |  |
 | settings.wssPort | int | `nil` | numeric port used for wss/https connections. If null, wss server will not be started |
+| terminationGracePeriodSeconds | int | `30` | Deployment's terminationGracePeriodSeconds |
 | tolerations | list | `[]` | Tolerations for pod assignment. |
 
 ----------------------------------------------

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "neon-proxy.labels" . | nindent 4 }}
 spec:
   strategy:
-    type: Recreate
+    {{- toYaml .Values.deploymentStrategy | nindent 4 }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -40,6 +40,7 @@ spec:
         - /bin/sh
         - -c
         - 'sysctl -w net.ipv4.tcp_keepalive_time=60; sysctl -w net.ipv4.tcp_keepalive_intvl=30'
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -140,6 +141,10 @@ spec:
               port: http
             periodSeconds: 15
             timeoutSeconds: 10
+          {{- if .Values.containerLifecycle }}
+          lifecycle:
+            {{- toYaml .Values.containerLifecycle | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if .Values.settings.domain }}

--- a/charts/neon-proxy/values.yaml
+++ b/charts/neon-proxy/values.yaml
@@ -4,6 +4,13 @@
 
 replicaCount: 1
 
+# -- strategy override for deployment
+deploymentStrategy:
+  type: Recreate
+
+# -- Deployment's terminationGracePeriodSeconds
+terminationGracePeriodSeconds: 30
+
 image:
   # -- Neondatabase image repository
   repository: neondatabase/neon
@@ -63,6 +70,9 @@ podLabels: {}
 # -- neon-proxy's pods Security Context
 podSecurityContext: {}
   # fsGroup: 2000
+
+# -- container lifecycle hooks specification for neon-proxy container
+containerLifecycle: {}
 
 # -- neon-proxy's containers Security Context
 securityContext: {}


### PR DESCRIPTION
In order to achieve zero downtime deployments, the deployment strategy needs to be customizable from `Recreate`, which pretty much ensures downtime.

`terminationGracePeriodSeconds` dictates for how long can the pods wait for being forcefully terminated, so it's essential to make that customizable too. The default is being set to kubernetes default.

Finally, since we might have different signal than the default for graceful shutdown, need to be able to customize the neon-proxy container's `lifecycle` to have that as `preStop` command.