### PR TITLE
Add support for extra certs for SCRAM proxy

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.6.2
+version: 1.6.3
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -64,6 +64,7 @@ Kubernetes: `^1.18.x-x`
 | settings.authBackend | string | `"link"` | auth method used (console|link|postgres) |
 | settings.authEndpoint | string | `""` | auth endpoint, e.g. "http://console.neon/authenticate_proxy_request/" |
 | settings.domain | string | `""` | domain used in TLS cert for client postgres connections |
+| settings.extraDomains | list | `[]` | domains used in extra TLS certs for client postgres connections |
 | settings.metricCollectionEndpoint | string | `""` | (url) endpoint used to send metrics to. If null, metrics will not be sent. |
 | settings.metricCollectionInterval | string | `""` | (string) how often metrics should be sent. |
 | settings.sentryEnvironment | string | `"development"` | "development" or "production". It will be visible in sentry in order to filter issues |

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.6.3](https://img.shields.io/badge/Version-1.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 

--- a/charts/neon-proxy/templates/_helpers.tpl
+++ b/charts/neon-proxy/templates/_helpers.tpl
@@ -64,8 +64,11 @@ Create the name of the service account to use
 {{/*
 Create the name for TLS certificate and it's secret
 */}}
+{{- define "neon-proxy.certificate-name" -}}
+{{- . | replace "." "-" | replace "*" "wildcard" -}}
+{{- end -}}
 {{- define "neon-proxy.certificate" -}}
-{{- .Values.settings.domain | replace "." "-" | replace "*" "wildcard" }}
+{{- include "neon-proxy.certificate-name" .Values.settings.domain }}
 {{- end }}
 {{- define "neon-proxy.certificate-secret" -}}
 {{ include "neon-proxy.certificate" . }}-tls

--- a/charts/neon-proxy/templates/_helpers.tpl
+++ b/charts/neon-proxy/templates/_helpers.tpl
@@ -67,9 +67,6 @@ Create the name for TLS certificate and it's secret
 {{- define "neon-proxy.certificate-name" -}}
 {{- . | replace "." "-" | replace "*" "wildcard" -}}
 {{- end -}}
-{{- define "neon-proxy.certificate" -}}
-{{- include "neon-proxy.certificate-name" .Values.settings.domain }}
-{{- end }}
 {{- define "neon-proxy.certificate-secret" -}}
-{{ include "neon-proxy.certificate" . }}-tls
+{{ include "neon-proxy.certificate-name" . }}-tls
 {{- end }}

--- a/charts/neon-proxy/templates/certificate.yaml
+++ b/charts/neon-proxy/templates/certificate.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "neon-proxy.certificate" . }}
+  name: {{ include "neon-proxy.certificate-name" .Values.settings.domain }}
 spec:
   commonName: {{ .Values.settings.domain | quote }}
   dnsNames:
@@ -11,7 +11,7 @@ spec:
     group: cert-manager.io
     kind: ClusterIssuer
     name: cert-manager-clusterissuer
-  secretName: {{ include "neon-proxy.certificate-secret" . }}
+  secretName: {{ include "neon-proxy.certificate-secret" .Values.settings.domain }}
   privateKey: 
     encoding: PKCS8
 {{- end }}

--- a/charts/neon-proxy/templates/certificates-extra.yaml
+++ b/charts/neon-proxy/templates/certificates-extra.yaml
@@ -1,0 +1,17 @@
+{{ range .Values.settings.extraDomains }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ . | replace "." "-" | replace "*" "wildcard" }}
+spec:
+  commonName: {{ . | quote }}
+  dnsNames:
+  - {{ . | quote }}
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: cert-manager-clusterissuer
+  secretName: {{ . | replace "." "-" | replace "*" "wildcard" }}-tls
+  privateKey: 
+    encoding: PKCS8
+{{ end }}

--- a/charts/neon-proxy/templates/certificates-extra.yaml
+++ b/charts/neon-proxy/templates/certificates-extra.yaml
@@ -11,7 +11,7 @@ spec:
     group: cert-manager.io
     kind: ClusterIssuer
     name: cert-manager-clusterissuer
-  secretName: {{ include "neon-proxy.certificate-name" . }}
+  secretName: {{ include "neon-proxy.certificate-secret" . }}
   privateKey: 
     encoding: PKCS8
 {{ end }}

--- a/charts/neon-proxy/templates/certificates-extra.yaml
+++ b/charts/neon-proxy/templates/certificates-extra.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ . | replace "." "-" | replace "*" "wildcard" }}
+  name: {{ include "neon-proxy.certificate-name" . }}
 spec:
   commonName: {{ . | quote }}
   dnsNames:
@@ -11,7 +11,7 @@ spec:
     group: cert-manager.io
     kind: ClusterIssuer
     name: cert-manager-clusterissuer
-  secretName: {{ . | replace "." "-" | replace "*" "wildcard" }}-tls
+  secretName: {{ include "neon-proxy.certificate-name" . }}
   privateKey: 
     encoding: PKCS8
 {{ end }}

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -112,7 +112,6 @@ spec:
               readOnly: true
             {{- end }}
           {{- end }}
-
           ports:
             - name: proxy
               containerPort: 5432
@@ -167,7 +166,6 @@ spec:
             secretName: {{ . | replace "." "-" | replace "*" "wildcard" }}-tls
         {{- end }}
       {{ end }}
-
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -88,7 +88,8 @@ spec:
             - /certs/tls.crt
             {{- end }}
             {{- if .Values.settings.extraDomains }}
-            - --certs-dir /certs-extra
+            - --certs-dir
+            - /certs-extra
             {{- end }}
           {{- if .Values.settings }}
           env:

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -86,7 +86,10 @@ spec:
             - /certs/tls.key
             - --tls-cert
             - /certs/tls.crt
-            {{ end }}
+            {{- end }}
+            {{- if .Values.settings.extraDomains }}
+            - --certs-dir /certs-extra
+            {{- end }}
           {{- if .Values.settings }}
           env:
             {{- with .Values.settings.sentryUrl }}
@@ -103,7 +106,13 @@ spec:
             - mountPath: "/certs"
               name: certs
               readOnly: true
+            {{- range .Values.settings.extraDomains }}
+            - mountPath: '/certs-extra/{{ . | replace "." "-" | replace "*" "wildcard" }}'
+              name: {{ . | replace "." "-" | replace "*" "wildcard" }}-tls
+              readOnly: true
+            {{- end }}
           {{- end }}
+
           ports:
             - name: proxy
               containerPort: 5432
@@ -152,7 +161,13 @@ spec:
         - name: certs
           secret:
             secretName: {{ include "neon-proxy.certificate-secret" . }}
+        {{- range .Values.settings.extraDomains }}
+        - name: {{ . | replace "." "-" | replace "*" "wildcard" }}-tls
+          secret:
+            secretName: {{ . | replace "." "-" | replace "*" "wildcard" }}-tls
+        {{- end }}
       {{ end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -107,8 +107,8 @@ spec:
               name: certs
               readOnly: true
             {{- range .Values.settings.extraDomains }}
-            - mountPath: '/certs-extra/{{ . | replace "." "-" | replace "*" "wildcard" }}'
-              name: {{ . | replace "." "-" | replace "*" "wildcard" }}-tls
+            - mountPath: '/certs-extra/{{ include "neon-proxy.certificate-name" . }}'
+              name: {{ include "neon-proxy.certificate-name" . }}
               readOnly: true
             {{- end }}
           {{- end }}
@@ -161,9 +161,9 @@ spec:
           secret:
             secretName: {{ include "neon-proxy.certificate-secret" . }}
         {{- range .Values.settings.extraDomains }}
-        - name: {{ . | replace "." "-" | replace "*" "wildcard" }}-tls
+        - name: {{ include "neon-proxy.certificate-name" . }}
           secret:
-            secretName: {{ . | replace "." "-" | replace "*" "wildcard" }}-tls
+            secretName: {{ include "neon-proxy.certificate-name" . }}
         {{- end }}
       {{ end }}
       {{- with .Values.nodeSelector }}

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -159,11 +159,11 @@ spec:
       volumes:
         - name: certs
           secret:
-            secretName: {{ include "neon-proxy.certificate-secret" . }}
+            secretName: {{ include "neon-proxy.certificate-secret" .Values.settings.domain }}
         {{- range .Values.settings.extraDomains }}
         - name: {{ include "neon-proxy.certificate-name" . }}
           secret:
-            secretName: {{ include "neon-proxy.certificate-name" . }}
+            secretName: {{ include "neon-proxy.certificate-secret" . }}
         {{- end }}
       {{ end }}
       {{- with .Values.nodeSelector }}

--- a/charts/neon-proxy/values.yaml
+++ b/charts/neon-proxy/values.yaml
@@ -37,6 +37,8 @@ settings:
   authBackend: "link"
   # settings.domain -- domain used in TLS cert for client postgres connections
   domain: ""
+  # settings.extraDomains -- domains used in extra TLS certs for client postgres connections
+  extraDomains: []
   # settings.sentryUrl -- url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in neon-proxy
   sentryUrl: ""
   # settings.sentryEnvironment -- "development" or "production". It will be visible in sentry in order to filter issues


### PR DESCRIPTION
- Creates TLS cert for each domain listed in extraDomains
- Mount them under subfolders of `/certs-extra`
- Passes that folder as `--certs-dir` to proxy

https://github.com/neondatabase/cloud/issues/4397