### PR TITLE
Use RollingUpdate for storage-broker

### DIFF
--- a/charts/neon-storage-broker/Chart.yaml
+++ b/charts/neon-storage-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-broker
 description: Neon storage broker
 type: application
-version: 1.1.1
+version: 1.2.0
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-broker/README.md
+++ b/charts/neon-storage-broker/README.md
@@ -1,6 +1,6 @@
 # neon-storage-broker
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage broker
 

--- a/charts/neon-storage-broker/templates/deployment.yaml
+++ b/charts/neon-storage-broker/templates/deployment.yaml
@@ -6,7 +6,10 @@ metadata:
     {{- include "neon-storage-broker.labels" . | nindent 4 }}
 spec:
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   replicas: 1
   # Which pods the Deployment is managing (duplicates template.metadata.labels).
   selector:


### PR DESCRIPTION
We had an issue with broker ~2 minutes downtime on redeploy (https://github.com/neondatabase/cloud/issues/5234). The cause of this issue is AWS Load Balancer, which takes 2 minutes to pass health checks for the new target.

This [page](https://aws.github.io/aws-eks-best-practices/networking/loadbalancing/loadbalancing/#utilize-pod-readiness-gates) suggests a fix for the problem:
1. Use RollingUpdate strategy for the service
2. Enable Readiness Gate for the LoadBalancer

This PR does the (1), and I also tested the fix by doing (2) manually:
```
kubectl label namespace neon-storage-broker-lb elbv2.k8s.aws/pod-readiness-gate-inject=enabled
```

AFAIK, there is no way to add namespace labels from a helm chart, so I will also create a PR in aws repository.