### PR TITLE
Use RollingUpdate strategy for SNI router

### DIFF
--- a/charts/neon-pg-sni-router/Chart.yaml
+++ b/charts/neon-pg-sni-router/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-pg-sni-router
 description: Neon Postgres SNI Router
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-pg-sni-router/README.md
+++ b/charts/neon-pg-sni-router/README.md
@@ -1,6 +1,6 @@
 # neon-pg-sni-router
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Postgres SNI Router
 
@@ -30,7 +30,7 @@ Kubernetes: `^1.18.x-x`
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for pod assignment |
 | containerLifecycle | object | `{}` | container lifecycle hooks specification for neon-pg-sni-router container |
-| deploymentStrategy | object | `{"type":"Recreate"}` | strategy override for deployment |
+| deploymentStrategy | object | `{"rollingUpdate":{"maxSurge":"100%","maxUnavailable":"50%"},"type":"RollingUpdate"}` | strategy override for deployment |
 | exposedService.annotations | object | `{}` | Annotations to add to the exposed service |
 | exposedService.httpsPort | int | `nil` | Exposed Service https port. If null, https server will not be exposed. |
 | exposedService.port | int | `5432` | Exposed Service proxy port |

--- a/charts/neon-pg-sni-router/values.yaml
+++ b/charts/neon-pg-sni-router/values.yaml
@@ -10,7 +10,10 @@ replicaCount: 1
 
 # -- strategy override for deployment
 deploymentStrategy:
-  type: Recreate
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 100%
+    maxUnavailable: 50%
 
 # -- Deployment's terminationGracePeriodSeconds
 terminationGracePeriodSeconds: 30


### PR DESCRIPTION
It was `Recreate` by default, which were causing a downtime each release.

I see that `proxy` also has `Recreate` by default and `RollingUpdate` is specified in the `aws` repo. Yet, for proxy it probably makes sense as link-auth and SCRAM proxies use different strategies and the same helm chart now. SNI router is completely stateless and using `RollingUpdate` by default is reasonable.

Related to neondatabase/cloud#5265