### PR TITLE
neon-storage-controller: add params for compute hook, readiness hook

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 
@@ -55,6 +55,8 @@ Kubernetes: `^1.18.x-x`
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| settings.computeHookUrl | string | `""` |  |
+| settings.controlPlaneJwtToken | string | `""` |  |
 | settings.databaseUrl | string | `""` |  |
 | settings.jwtToken | string | `""` |  |
 | settings.publicKey | string | `""` |  |

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -52,12 +52,19 @@ spec:
             - {{ .Values.settings.databaseUrl }}
           {{- end }}
           {{- if .Values.settings.jwtToken }}
-            - --jwt
+            - --jwt-token
             - {{ .Values.settings.jwtToken }}
           {{- end }}
           {{- if .Values.settings.publicKey }}
-            - --public-key
-            - {{ .Values.settings.publicKey }}
+            - --public-key={{ .Values.settings.publicKey | toJson }}
+          {{- end }}
+          {{- if .Values.settings.controlPlaneJwtToken }}
+            - --control-plane-jwt-token
+            - {{ .Values.settings.controlPlaneJwtToken }}
+          {{- end }}
+          {{- if .Values.settings.computeHookUrl }}
+            - --compute-hook-url
+            - {{ .Values.settings.computeHookUrl }}
           {{- end }}
           env:
             - name: LD_LIBRARY_PATH
@@ -92,7 +99,7 @@ spec:
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /status
+              path: /ready
               port: controller
             periodSeconds: 15
             timeoutSeconds: 10

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -30,6 +30,10 @@ settings:
   jwtToken: ""
   # May be set if AWS Secrets Manager is not being used: public key for authenticating incoming HTTP requests
   publicKey: ""
+  # May be set if AWS Secrets Manager is not being used: JWT token for authenticating calls to computeHookUrl
+  controlPlaneJwtToken: ""
+  # URL for compute notifications
+  computeHookUrl: ""
 
 serviceAccount:
   # serviceAccount.create - Specifies whether a service account should be created


### PR DESCRIPTION
Intentionally not bumping the version because this can stay at 1.0.0 util it is stabilized enough to go into prod use.

- Fix jwtToken variable handling
- Add controlPlaneJwtToken, computeHookUrl
- Use recently added `/ready` endpoint as readiness check.