### PR TITLE
fix: storage controller registration script

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 

--- a/charts/neon-storage-controller/scripts/register-storage-controller.py
+++ b/charts/neon-storage-controller/scripts/register-storage-controller.py
@@ -132,7 +132,9 @@ if __name__ == "__main__":
     PAYLOAD.update(dict(version=version))
 
     log.info("check if pageserver already registered or not in console")
-    node_id_in_console = get_pageserver_id(GLOBAL_CPLANE_URL, GLOBAL_CPLANE_JWT_TOKEN)
+    node_id_in_console = get_pageserver_id(
+        GLOBAL_CPLANE_URL, GLOBAL_CPLANE_JWT_TOKEN
+    )
 
     if node_id_in_console is None:
         log.info("Registering storage controller in console")
@@ -150,12 +152,16 @@ if __name__ == "__main__":
         )
 
     log.info("check if pageserver already registered or not in cplane")
-    node_id_in_cplane = get_pageserver_id(LOCAL_CPLANE_URL, LOCAL_CPLANE_JWT_TOKEN)
+    node_id_in_cplane = get_pageserver_id(
+        LOCAL_CPLANE_URL, LOCAL_CPLANE_JWT_TOKEN
+    )
 
     if node_id_in_cplane is None and node_id_in_console is not None:
         PAYLOAD.update(dict(node_id=node_id_in_console))
         log.info("Registering storage controller in cplane")
-        node_id_in_cplane = register(LOCAL_CPLANE_URL, LOCAL_CPLANE_JWT_TOKEN, PAYLOAD)
+        node_id_in_cplane = register(
+            LOCAL_CPLANE_URL, LOCAL_CPLANE_JWT_TOKEN, PAYLOAD
+        )
         log.info(
             f"Storage controller registered in cplane with node_id \
             {node_id_in_cplane}"

--- a/charts/neon-storage-controller/scripts/register-storage-controller.py
+++ b/charts/neon-storage-controller/scripts/register-storage-controller.py
@@ -65,7 +65,7 @@ def get_data(url, token, host=None):
 def get_pageserver_id(url, token):
     data = get_data(url, token, HOST)
     if "node_id" in data:
-        return data["node_id"]
+        return int(data["node_id"])
 
 
 def get_pageserver_version():
@@ -97,7 +97,7 @@ def register(url, token, payload):
         response = json.loads(resp.read())
     log.info(response)
     if "node_id" in response:
-        return response["node_id"]
+        return int(response["node_id"])
 
 
 if __name__ == "__main__":
@@ -152,8 +152,8 @@ if __name__ == "__main__":
     log.info("check if pageserver already registered or not in cplane")
     node_id_in_cplane = get_pageserver_id(LOCAL_CPLANE_URL, LOCAL_CPLANE_JWT_TOKEN)
 
-    if node_id_in_cplane is None:
-        PAYLOAD.update(dict(node_id=str(node_id_in_console)))
+    if node_id_in_cplane is None and node_id_in_console is not None:
+        PAYLOAD.update(dict(node_id=node_id_in_console))
         log.info("Registering storage controller in cplane")
         node_id_in_cplane = register(LOCAL_CPLANE_URL, LOCAL_CPLANE_JWT_TOKEN, PAYLOAD)
         log.info(


### PR DESCRIPTION
Cplane only accept `node_id` as integer and script were sending string. 

```
neon-control-plane-api-0 neon-control-plane {"level":"ERR","ts":"2024-03-04T12:51:53.388Z","logger":"managementapiv2","message":"incoming request finished with error","http_meth":"POST","http_path":"/management/api/v2/pageservers","route":"PageserverRegister","request_id":"8c1da1d9ae780811e3debd558cc261b6","trace_id":"2qCK96h5WSEyyNMa4CB9Qc","ingress_duration_ms":0,"status":400,"error":"invalid request: decode application/json: decode PageserverRegisterRequest: callback: decode field \"node_id\": unexpected byte 34 '\"' at 495: operation PageserverRegister: decode request: decode application/json: decode PageserverRegisterRequest: callback: decode field \"node_id\": unexpected byte 34 '\"' at 495","errorVerbose":"invalid request: decode application/json: decode PageserverRegisterRequest: callback: decode field \"node_id\": unexpected byte 34 '\"' at 495:\n    github.com/neondatabase/cloud/internal/semerr.errFmt\n        /build/internal/semerr/semantic.go:65\n  - operation PageserverRegister: decode request:\n      - decode application/json:\n        body: {\"host\": \"storage-controller.beta.us-east-2.internal.aws.neon.build\", \"region_id\": \"aws-us-east-2\", \"port\": 6400, \"disk_size\": 0, \"instance_id\": \"storage-controller.beta.us-east-2.internal.aws.neon.build\", \"http_host\": \"storage-controller.beta.us-east-2.internal.aws.neon.build\", \"http_port\": 50051, \"availability_zone_id\": \"us-east-2c\", \"instance_type\": \"\", \"register_reason\": \"Storage Controller Virtual Pageserver\", \"active\": false, \"is_storage_controller\": true, \"version\": 4767, \"node_id\": \"9315\"}\n
```