### PR TITLE
double quotes value in deployment envs

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -45,28 +45,30 @@ spec:
           command:
             - storage_controller
             - -l
+            {{- /*
             # In the container, use the same port as service.
+            */}}
             - 0.0.0.0:{{ .Values.service.port }}
             - --public-key={{ .Values.settings.publicKey | toJson }}
           {{- if .Values.settings.computeHookUrl }}
             - --compute-hook-url
-            - {{ .Values.settings.computeHookUrl }}
+            - {{ .Values.settings.computeHookUrl | quote }}
           {{- end }}
           env:
             - name: LD_LIBRARY_PATH
-              value: /usr/local/v16/lib
+              value: "/usr/local/v16/lib"
             - name: RUST_LOG
-              value: INFO
+              value: "INFO"
             - name: RUST_BACKTRACE
-              value: 1
+              value: "1"
           {{- if .Values.settings }}
             {{- with .Values.settings.sentryUrl }}
             - name: SENTRY_DSN
-              value: {{ . }}
+              value: {{ . | quote }}
             {{- end }}
             {{- with .Values.settings.sentryEnvironment }}
             - name: SENTRY_ENVIRONMENT
-              value: {{ . }}
+              value: {{ . | quote }}
             {{- end }}
           {{- end }}
           envFrom:


### PR DESCRIPTION
## Description

Helm deployment failed with following error:

```
Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```

Ref: https://github.com/neondatabase/aws/actions/runs/8202890489/job/22434609060