### PR TITLE
controller: add default resource limits

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.0.8
+version: 1.0.9
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 
@@ -48,13 +48,10 @@ Kubernetes: `^1.18.x-x`
 | registerControlPlane.apiKey | string | `""` |  |
 | registerControlPlane.controlPlaneJwtToken | string | `""` |  |
 | registerControlPlane.enable | bool | `false` |  |
-| registerControlPlane.resources.limits.cpu | string | `"100m"` |  |
-| registerControlPlane.resources.limits.memory | string | `"128M"` |  |
-| registerControlPlane.resources.requests.cpu | string | `"100m"` |  |
-| registerControlPlane.resources.requests.memory | string | `"128M"` |  |
-| resources.limits.memory | string | `"4Gi"` |  |
-| resources.requests.cpu | string | `"200m"` |  |
-| resources.requests.memory | string | `"1Gi"` |  |
+| resources.limits.cpu | string | `"1000m"` |  |
+| resources.limits.memory | string | `"1024M"` |  |
+| resources.requests.cpu | string | `"500m"` |  |
+| resources.requests.memory | string | `"512M"` |  |
 | securityContext | object | `{}` | neon-storage-controller's containers Security Context |
 | service.annotations | object | `{}` | Annotations to add to the service |
 | service.port | int | `50051` | controller listen port |

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -52,13 +52,14 @@ registerControlPlane:
   # global_cplane_url: "http://neon-internal-api.aws.neon.build"
   # local_cplane_url: "https://control-plane.zeta.us-east-2.internal.aws.neon.build"
   # console_url: ""
-  resources:
-    limits:
-      cpu: 100m
-      memory: 128M
-    requests:
-      cpu: 100m
-      memory: 128M
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1024M
+  requests:
+    cpu: 500m
+    memory: 512M
 
 serviceAccount:
   # serviceAccount.create - Specifies whether a service account should be created
@@ -98,13 +99,6 @@ service:
   type: ClusterIP
   # service.port -- controller listen port
   port: 50051
-
-resources:
-  limits:
-    memory: 4Gi
-  requests:
-    cpu: 200m
-    memory: 1Gi
 
 # -- Node labels for pod assignment.
 nodeSelector: {}


### PR DESCRIPTION
There was a broken `resources` block (bad indentation), with tiny resource limits.

This PR fixes the indentation and sets more modest limits (1Gb, 1 CPU core).  This facilitates better alerting (I will alert on going above 50% of these limits)