### PR TITLE
storage controller: don't `| quote` split threshold

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.0.9
+version: 1.0.10
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.0.10](https://img.shields.io/badge/Version-1.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           {{- end }}
           {{- if .Values.settings.splitThreshold }}
             - --split-threshold
-            - {{ .Values.settings.splitThreshold | quote }}
+            - {{ .Values.settings.splitThreshold }}
           {{- end }}
           env:
             - name: LD_LIBRARY_PATH


### PR DESCRIPTION
Helm (or Go formatting more generally) apparently arbitrarily uses scientific notation for integers above a million when quoting.

Try passing it through without the `| quote` to see if a simple integer makes it through unscathed.