### PR TITLE
show errors received on registration

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.0.11
+version: 1.0.12
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.0.12](https://img.shields.io/badge/Version-1.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.0.12](https://img.shields.io/badge/Version-1.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.0.11](https://img.shields.io/badge/Version-1.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.0.12](https://img.shields.io/badge/Version-1.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 

--- a/charts/neon-storage-controller/scripts/register-storage-controller.py
+++ b/charts/neon-storage-controller/scripts/register-storage-controller.py
@@ -53,13 +53,13 @@ def get_data(url, token, host=None):
     }
     # Check if the server is already registered
     req = urllib.request.Request(url=url, headers=headers, method="GET")
-    try:
-        with urllib.request.urlopen(req) as response:
-            if response.getcode() == 200:
-                return json.loads(response.read())
-    except urllib.error.URLError:
-        pass
-    return {}
+    with urllib.request.urlopen(req) as response:
+        code = response.getcode()
+        response_body = response.read()
+        if code == 200:
+            return json.loads(response_body)
+
+        raise Exception(f'GET {url} returned unexpected response: {code} {response_body}')
 
 
 def get_pageserver_id(url, token):

--- a/charts/neon-storage-controller/scripts/register-storage-controller.py
+++ b/charts/neon-storage-controller/scripts/register-storage-controller.py
@@ -53,13 +53,16 @@ def get_data(url, token, host=None):
     }
     # Check if the server is already registered
     req = urllib.request.Request(url=url, headers=headers, method="GET")
-    with urllib.request.urlopen(req) as response:
-        code = response.getcode()
-        response_body = response.read()
-        if code == 200:
-            return json.loads(response_body)
+    try:
+        with urllib.request.urlopen(req) as response:
+            code = response.getcode()
+            response_body = response.read()
+            if code == 200:
+                return json.loads(response_body)
 
-        raise Exception(f'GET {url} returned unexpected response: {code} {response_body}')
+            raise Exception(f'GET {url} returned unexpected response: {code} {response_body}')
+    except urllib.error.HTTPError as e:
+        raise Exception(f'GET {e.url} returned unexpected response: {e.code}') from e
 
 
 def get_pageserver_id(url, token):

--- a/charts/neon-storage-controller/scripts/register-storage-controller.py
+++ b/charts/neon-storage-controller/scripts/register-storage-controller.py
@@ -57,12 +57,14 @@ def get_data(url, token, host=None):
         with urllib.request.urlopen(req) as response:
             code = response.getcode()
             response_body = response.read()
-            if code == 200:
-                return json.loads(response_body)
-
-            raise Exception(f'GET {url} returned unexpected response: {code} {response_body}')
     except urllib.error.HTTPError as e:
-        raise Exception(f'GET {e.url} returned unexpected response: {e.code}') from e
+        code = e.code
+        response_body = e.read()
+
+    if code == 200:
+        return json.loads(response_body)
+
+    raise Exception(f'GET {url} returned unexpected response: {code} {response_body}')
 
 
 def get_pageserver_id(url, token):


### PR DESCRIPTION
Currently I'm trying to setup a storage controller in a new environment but registration is failing
with a `Unable to find pageserver version from` message, which doesn't tell much. I'm sure there's a
configuration error somewhere but it's hard to debug when the message doesn't contain any details.

This PR changes the `get_data` method to raise an exception on unexpected responses so that the
status code and response body are shown. Also changes the same method to not silently discard
`urllib.error.URLError` if it happens.

This doesn't change the behavior of the registration script significantly because we're already
exiting if the response doesn't contain what we need.
