### PR TITLE
[proxy/cplane-communication] refactor: support switching auth type

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.7.25
+version: 1.7.26
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.7.25](https://img.shields.io/badge/Version-1.7.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.7.26](https://img.shields.io/badge/Version-1.7.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -92,6 +92,7 @@ Kubernetes: `^1.18.x-x`
 | settings.parquetUploadRemoteStorage | string | `""` | (string) Storage location to upload the parquet files to. |
 | settings.parquetUploadRowGroupSize | string | `"8192"` | (string) How many rows to include in a row group |
 | settings.parquetUploadSize | string | `"100000000"` | (string) How large the total parquet file should be in bytes |
+| settings.redisAuthType | string | `"irsa"` | (string) What auth type to use for regional Redis client. "irsa" and "plain" are supported. "plain" means use URI from settings.redisNotifications. "irsa" means AWS IRSA. |
 | settings.redisClusterName | string | `"regional-control-plane-redis"` | (string) Redis cluster name, used in aws elasticache |
 | settings.redisHost | string | `""` | (string) Redis host for streaming connections (might be different from the notifications host) |
 | settings.redisNotifications | string | `""` | (url) Configures redis client |

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.7.26](https://img.shields.io/badge/Version-1.7.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.7.26](https://img.shields.io/badge/Version-1.7.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -156,6 +156,10 @@ spec:
             - --redis-notifications
             - {{ . }}
             {{- end }}
+            {{- with .Values.settings.redisAuthType}}
+            - --redis-auth-type
+            - {{ . }}
+            {{- end }}
             {{- with .Values.settings.metricBackupCollectionInterval }}
             - --metric-backup-collection-interval={{ . }}
             {{ end }}

--- a/charts/neon-proxy/values.yaml
+++ b/charts/neon-proxy/values.yaml
@@ -65,6 +65,8 @@ settings:
   connectComputeLock: ""
   # settings.redisNotifications -- (url) Configures redis client
   redisNotifications: ""
+  # settings.redisAuthType -- (string) What auth type to use for regional Redis client. "irsa" and "plain" are supported. "plain" means use URI from settings.redisNotifications. "irsa" means AWS IRSA.
+  redisAuthType: "irsa"
   # settings.sqlOverHttpTimeout -- (string) timeout for http connection requests
   sqlOverHttpTimeout: "15s"
   # settings.httpPoolOptIn -- (bool) Sets the SQL over HTTP Pool to opt-in-only mode if true. Set false to enable it always


### PR DESCRIPTION


This adds additional parameter, `--redis-auth-type` to proxy startup CLI arguments. The default is "irsa", and it should be a backward compatible default.

https://github.com/neondatabase/cloud/issues/14462
