### PR TITLE
storage-scrubber: enable jwt auth with storage controller

### DIFF
--- a/charts/neon-storage-scrubber/Chart.yaml
+++ b/charts/neon-storage-scrubber/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-scrubber
 description: neon-storage-scrubber
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "v0.1.0"
 sources:
   - https://github.com/neondatabase/neon/tree/main/storage_scrubber

--- a/charts/neon-storage-scrubber/README.md
+++ b/charts/neon-storage-scrubber/README.md
@@ -1,6 +1,6 @@
 # neon-storage-scrubber
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 neon-storage-scrubber
 
@@ -47,7 +47,7 @@ $ helm install neon-storage-scrubber neondatabase/neon-storage-scrubber
 | storageScrubber.command | list | `["pageserver-physical-gc","--min-age=1week"]` | The command to run |
 | storageScrubber.enableStorageControllerConnection | bool | `false` | Enable storage controller related functionalities |
 | storageScrubber.schedule | string | `"0 18 * * *"` |  |
-| storageScrubber.storageControllerJwtToken | string | `""` | Control plane / storage controller JWT token for connecting to the storage controller  |
+| storageScrubber.storageControllerJwtToken | string | `""` | Control plane / storage controller JWT token for connecting to the storage controller |
 | storageScrubber.storageControllerUrl | string | `""` | URL of the storage controller |
 | storageScrubber.timeZone | string | `"Etc/UTC"` | The timezone for the cron job |
 | tolerations | list | `[]` | Tolerations for pod assignment. |

--- a/charts/neon-storage-scrubber/README.md
+++ b/charts/neon-storage-scrubber/README.md
@@ -44,8 +44,11 @@ $ helm install neon-storage-scrubber neondatabase/neon-storage-scrubber
 | settings.sentryUrl | string | `""` | url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in neon-pg-sni-router |
 | storageScrubber.awsBucket | string | `""` | The AWS bucket for the pageserver storage |
 | storageScrubber.awsRegion | string | `""` | The AWS region to run the scrubber |
-| storageScrubber.command | list | `["/usr/local/bin/storage_scrubber","pageserver-physical-gc","--min-age=1week"]` | The command to run |
+| storageScrubber.command | list | `["pageserver-physical-gc","--min-age=1week"]` | The command to run |
+| storageScrubber.enableStorageControllerConnection | bool | `false` | Enable storage controller related functionalities |
 | storageScrubber.schedule | string | `"0 18 * * *"` |  |
+| storageScrubber.storageControllerJwtToken | string | `""` | Control plane / storage controller JWT token for connecting to the storage controller  |
+| storageScrubber.storageControllerUrl | string | `""` | URL of the storage controller |
 | storageScrubber.timeZone | string | `"Etc/UTC"` | The timezone for the cron job |
 | tolerations | list | `[]` | Tolerations for pod assignment. |
 

--- a/charts/neon-storage-scrubber/templates/cronjob.yaml
+++ b/charts/neon-storage-scrubber/templates/cronjob.yaml
@@ -40,6 +40,13 @@ spec:
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command:
+                - /usr/local/bin/storage_scrubber
+                {{- if .Values.storageScrubber.enableStorageControllerConnection }}
+                - "--controller-jwt"
+                - "$(STORAGE_CONTROLLER_JWT)"
+                - "--controller-api"
+                - {{ .Values.storageScrubber.storageControllerUrl | quote }}
+                {{- end -}}
                 {{- toYaml .Values.storageScrubber.command | nindent 16 }}
               env:
                 - name: BUCKET
@@ -59,6 +66,9 @@ spec:
                 {{- toYaml . | nindent 16 }}
                 {{- end }}
                 {{- end }}
+              envFrom:
+                - secretRef:
+                    name: {{ include "neon-storage-scrubber.fullname" . }}-env-vars
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
           {{- with .Values.nodeSelector }}

--- a/charts/neon-storage-scrubber/templates/secrets.yaml
+++ b/charts/neon-storage-scrubber/templates/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "neon-storage-scrubber.fullname" . }}-env-vars
+  labels:
+    {{- include "neon-storage-scrubber.labels" . | nindent 4 }}
+type: Opaque
+data:
+  STORAGE_CONTROLLER_JWT_TOKEN: {{ .Values.storageScrubber.storageControllerJwtToken | b64enc | quote }}

--- a/charts/neon-storage-scrubber/values.yaml
+++ b/charts/neon-storage-scrubber/values.yaml
@@ -34,9 +34,9 @@ settings:
   # settings.extraEnvs -- extra env variables when running the job
   extraEnvs:
     - name: RUST_BACKTRACE
-      value: '1'
+      value: "1"
     - name: PAGESERVER_DISABLE_FILE_LOGGING
-      value: '1'
+      value: "1"
 
 storageScrubber:
   # -- The AWS region to run the scrubber
@@ -53,11 +53,10 @@ storageScrubber:
     - --min-age=1week
   # -- Enable storage controller related functionalities
   enableStorageControllerConnection: false
-  # -- Control plane / storage controller JWT token for connecting to the storage controller 
+  # -- Control plane / storage controller JWT token for connecting to the storage controller
   storageControllerJwtToken: ""
   # -- URL of the storage controller
   storageControllerUrl: ""
-
 
 # -- Annotations for neon-storage-scrubber pods
 podAnnotations: {}

--- a/charts/neon-storage-scrubber/values.yaml
+++ b/charts/neon-storage-scrubber/values.yaml
@@ -31,7 +31,7 @@ settings:
   sentryUrl: ""
   # settings.sentryEnvironment -- "development" or "production". It will be visible in sentry in order to filter issues
   sentryEnvironment: "development"
-  # -- extra env variables when running the job
+  # settings.extraEnvs -- extra env variables when running the job
   extraEnvs:
     - name: RUST_BACKTRACE
       value: '1'
@@ -49,9 +49,15 @@ storageScrubber:
   schedule: "0 18 * * *"
   # -- The command to run
   command:
-    - /usr/local/bin/storage_scrubber
     - pageserver-physical-gc
     - --min-age=1week
+  # -- Enable storage controller related functionalities
+  enableStorageControllerConnection: false
+  # -- Control plane / storage controller JWT token for connecting to the storage controller 
+  storageControllerJwtToken: ""
+  # -- URL of the storage controller
+  storageControllerUrl: ""
+
 
 # -- Annotations for neon-storage-scrubber pods
 podAnnotations: {}


### PR DESCRIPTION
This pull request adds 3 fields to the helm chart to support scrubber<->controller auth.

```
  # -- Enable storage controller related functionalities
  enableStorageControllerConnection: false
  # -- Control plane / storage controller JWT token for connecting to the storage controller
  storageControllerJwtToken: ""
  # -- URL of the storage controller
  storageControllerUrl: ""
```

Also, users no longer need to supply the executable path in the command field.

Tested by deploying this chart to dev-us-east-2 and it works.