### PR TITLE
[proxy/dualstack] impr: allow specify ipFamilies for external LB

### DIFF
--- a/charts/neon-proxy/templates/service.exposed.yaml
+++ b/charts/neon-proxy/templates/service.exposed.yaml
@@ -9,6 +9,9 @@ metadata:
   labels:
     {{- include "neon-proxy.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.exposedService.ipFamilies }}
+  ipFamilies: {{ . | toYaml | nindent 2 }}
+  {{- end }}
   type: {{ .Values.exposedService.type }}
   ports:
     - port: {{ .Values.exposedService.port }}

--- a/charts/neon-proxy/values.yaml
+++ b/charts/neon-proxy/values.yaml
@@ -166,6 +166,8 @@ service:
   httpPort: 9090
 
 exposedService:
+  # In AKS to provision dual stack LB one needs to set ipFamilies to ["IPv4", "IPv6"]
+  ipFamilies: null
   # exposedService.annotations -- Annotations to add to the exposed service
   annotations: {}
     # service.beta.kubernetes.io/aws-load-balancer-type: external


### PR DESCRIPTION
This adds `.Values.exposedService.ipFamilies` to allow requesting dual stack external Load Balancer in Azure Cloud.

Merge only after provisioning https://github.com/neondatabase/azure/pull/311