### PR TITLE
Inject address for peers at storage controller start-up

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -59,6 +59,8 @@ spec:
             - --chaos-interval
             - {{ .Values.settings.chaosInterval | quote }}
           {{- end }}
+            - --address-for-peers
+            - http://$(POD_IP):{{ .Values.service.port }}/
           env:
             - name: LD_LIBRARY_PATH
               value: "/usr/local/v16/lib"
@@ -66,6 +68,10 @@ spec:
               value: "INFO"
             - name: RUST_BACKTRACE
               value: "1"
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           {{- if .Values.settings }}
             {{- with .Values.settings.sentryUrl }}
             - name: SENTRY_DSN


### PR DESCRIPTION
The storage controller needs to know the address at which it is reachable by it's peers within the deployment. It will use this to mark itself as the leader in the database.

The CLI arg was added in https://github.com/neondatabase/neon/pull/8588 and that's already been deployed everywhere.

Note that we are not enabling graceful leadership tranfers with this change. The only change in storcon behaviour is that each instance will write its address into the database at start-up. If that fails, the process exits.