### PR TITLE
Add helm chart option for graceful service restart

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.1.3
+version: 1.1.4
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 
@@ -72,6 +72,7 @@ Kubernetes: `^1.18.x-x`
 | settings.sentryEnvironment | string | `"development"` | "development" or "production". It will be visible in sentry in order to filter issues |
 | settings.sentryUrl | string | `""` | url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in storage-controller |
 | settings.splitThreshold | string | `""` | Size threshold in bytes for automatically sharding a tenant.  Omit to disable auto-sharding (default) |
+| settings.startAsCandidate | bool | `false` | When set to True, restart the service gracefully |
 | tolerations | list | `[]` | Tolerations for pod assignment. |
 
 ----------------------------------------------

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -6,7 +6,14 @@ metadata:
     {{- include "neon-storage-controller.labels" . | nindent 4 }}
 spec:
   strategy:
+  {{- if .Values.settings.startAsCandidate }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  {{- else }}
     type: Recreate
+  {{- end }}
   replicas: 1
   # Which pods the Deployment is managing (duplicates template.metadata.labels).
   selector:
@@ -61,6 +68,9 @@ spec:
           {{- end }}
             - --address-for-peers
             - http://$(POD_IP):{{ .Values.service.port }}/
+          {{- if .Values.settings.startAsCandidate }}
+            - --start-as-candidate
+          {{- end }}
           env:
             - name: LD_LIBRARY_PATH
               value: "/usr/local/v16/lib"

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -40,6 +40,8 @@ settings:
   splitThreshold: ""
   # -- Chaos testing interval
   chaosInterval: ""
+  # -- When set to True, restart the service gracefully
+  startAsCandidate: false
 
 
 # Enable auto register to control plane


### PR DESCRIPTION
Add a `startAsCandidate` setting for the storcon helm chart (default `false`).
When set to true, the service restarts gracefully (see https://github.com/neondatabase/neon/pull/8310).

This doesn't change anything as is. Changes to `neondatabase/infra` will stage the roll-out of this.