### PR TITLE
Add support foir changing proxy Service's externalTrafficPolicy

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.7.28
+version: 1.8.0
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.7.28](https://img.shields.io/badge/Version-1.7.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 
@@ -31,6 +31,7 @@ Kubernetes: `^1.18.x-x`
 | containerLifecycle | object | `{}` | container lifecycle hooks specification for neon-proxy container |
 | deploymentStrategy | object | `{"type":"Recreate"}` | strategy override for deployment |
 | exposedService.annotations | object | `{}` | Annotations to add to the exposed service |
+| exposedService.externalTrafficPolicy | string | `"Cluster"` | externalTrafficPolicy (Cluster, Internal) |
 | exposedService.httpsPort | int | `nil` | Exposed Service https port. If null, https server will not be exposed. |
 | exposedService.port | int | `5432` | Exposed Service proxy port |
 | exposedService.type | string | `"LoadBalancer"` | Exposed service type |

--- a/charts/neon-proxy/templates/service.exposed.yaml
+++ b/charts/neon-proxy/templates/service.exposed.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- include "neon-proxy.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.exposedService.type }}
+  externalTrafficPolicy: {{ .Values.exposedService.externalTrafficPolicy }}
   ports:
     - port: {{ .Values.exposedService.port }}
       targetPort: proxy

--- a/charts/neon-proxy/values.yaml
+++ b/charts/neon-proxy/values.yaml
@@ -174,6 +174,8 @@ exposedService:
     # external-dns.alpha.kubernetes.io/hostname: chart-example.local
   # exposedService.type -- Exposed service type
   type: LoadBalancer
+  # exposedService.externalTrafficPolicy -- externalTrafficPolicy (Cluster, Internal)
+  externalTrafficPolicy: Cluster
   # exposedService.port -- Exposed Service proxy port
   port: 5432
   # exposedService.httpsPort -- (int) Exposed Service https port. If null, https server will not be exposed.


### PR DESCRIPTION
Across providers there might be a need to change externalTrafficPolicy for the external Service. Keep the default as Cluster, which is the default in Kubernetes.