### PR TITLE
proxy: Add support for additional command line arguments

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.8.0
+version: 1.8.1
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 
@@ -77,6 +77,7 @@ Kubernetes: `^1.18.x-x`
 | settings.domain | string | `""` | domain used in TLS cert for client postgres connections |
 | settings.endpointCacheConfig | string | `""` | (string) Config for cache for all valid endpoints |
 | settings.endpointRpsLimits | list | `[]` | (list) list of rate limiters for connection attempts over different time intervals |
+| settings.extraCmdFlags | list | `[]` | (list) additional arguments to proxy binary |
 | settings.extraDomains | list | `[]` | domains used in extra TLS certs for client postgres connections |
 | settings.httpPoolOptIn | bool | `true` | (bool) Sets the SQL over HTTP Pool to opt-in-only mode if true. Set false to enable it always |
 | settings.metricBackupCollectionChunkSize | string | `"4194304"` | (string) How large each chunk of the metric backup files should be in bytes |

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -187,7 +187,9 @@ spec:
             {{- with .Values.settings.awsRegion }}
             - --aws-region={{ . }}
             {{ end }}
-
+            {{- with .Values.settings.extraCmdFlags }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
 
           {{- if .Values.settings }}
           env:

--- a/charts/neon-proxy/values.yaml
+++ b/charts/neon-proxy/values.yaml
@@ -119,6 +119,8 @@ settings:
   redisUserId: "neon"
   # settings.awsRegion -- (string) Aws region to retrieve credentials
   awsRegion: ""
+  # settings.extraCmdFlags -- (list) additional arguments to proxy binary
+  extraCmdFlags: []
 
 serviceAccount:
   # serviceAccount.create - Specifies whether a service account should be created


### PR DESCRIPTION
## Description

- Add support for additional command line arguments
- This will be use to deploy proxy in private access mode i.e. `--is-private-access-proxy` flag


Ref: https://github.com/neondatabase/neon/issues/9033