### PR TITLE
storage_controller: make long reconcile threshold a value

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.1.4
+version: 1.1.5
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 
@@ -73,6 +73,7 @@ Kubernetes: `^1.18.x-x`
 | settings.sentryUrl | string | `""` | url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in storage-controller |
 | settings.splitThreshold | string | `""` | Size threshold in bytes for automatically sharding a tenant.  Omit to disable auto-sharding (default) |
 | settings.startAsCandidate | bool | `false` | When set to True, restart the service gracefully |
+| settings.startAsCandidate | string | `"30min"` | If a reconciliation takes longer than this, bump an alerting metric |
 | tolerations | list | `[]` | Tolerations for pod assignment. |
 
 ----------------------------------------------

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
           {{- if .Values.settings.startAsCandidate }}
             - --start-as-candidate
           {{- end }}
+          {{- if .Values.settings.longReconcileThreshold }}
+            - --long-reconcile-threshold
+            - {{ .Values.settings.longReconcileThreshold | quote }}
+          {{- end }}
           env:
             - name: LD_LIBRARY_PATH
               value: "/usr/local/v16/lib"

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -42,6 +42,8 @@ settings:
   chaosInterval: ""
   # -- When set to True, restart the service gracefully
   startAsCandidate: false
+  # -- If a reconciliation takes longer than this, bump an alerting metric
+  longReconcileThreshold: "30min"
 
 
 # Enable auto register to control plane


### PR DESCRIPTION
We want to set this thing, but the helm chart didn't support it.