### PR TITLE
Add remoteStorageConfig variable to neon-storage-scrubber

### DIFF
--- a/charts/neon-storage-scrubber/Chart.yaml
+++ b/charts/neon-storage-scrubber/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-scrubber
 description: neon-storage-scrubber
 type: application
-version: 1.2.0
+version: 1.3.0
 appVersion: "v0.1.0"
 sources:
   - https://github.com/neondatabase/neon/tree/main/storage_scrubber

--- a/charts/neon-storage-scrubber/README.md
+++ b/charts/neon-storage-scrubber/README.md
@@ -47,6 +47,7 @@ $ helm install neon-storage-scrubber neondatabase/neon-storage-scrubber
 | storageScrubber.awsRegion | string | `""` | The AWS region to run the scrubber |
 | storageScrubber.command | list | `["pageserver-physical-gc","--min-age=1week"]` | The command to run |
 | storageScrubber.enableStorageControllerConnection | bool | `false` | Enable storage controller related functionalities |
+| storageScrubber.remoteStorageConfig | object | `{}` | The config object to connect to the remote storage (alternative to previous two vars) |
 | storageScrubber.schedule | string | `"0 18 * * *"` |  |
 | storageScrubber.storageControllerJwtToken | string | `""` | Control plane / storage controller JWT token for connecting to the storage controller |
 | storageScrubber.storageControllerUrl | string | `""` | URL of the storage controller |

--- a/charts/neon-storage-scrubber/README.md
+++ b/charts/neon-storage-scrubber/README.md
@@ -1,6 +1,6 @@
 # neon-storage-scrubber
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 neon-storage-scrubber
 

--- a/charts/neon-storage-scrubber/templates/cronjob.yaml
+++ b/charts/neon-storage-scrubber/templates/cronjob.yaml
@@ -60,7 +60,8 @@ spec:
                 {{- end }}
                 {{- if .Values.storageScrubber.remoteStorageConfig }}
                 - name: REMOTE_STORAGE_CONFIG
-                  value: {{ toToml .Values.storageScrubber.remoteStorageConfig | nindent 20 }}
+                  value: |
+                    {{- toToml .Values.storageScrubber.remoteStorageConfig | nindent 20 }}
                 {{- end }}
                 {{- if .Values.settings }}
                 {{- with .Values.settings.sentryUrl }}

--- a/charts/neon-storage-scrubber/templates/cronjob.yaml
+++ b/charts/neon-storage-scrubber/templates/cronjob.yaml
@@ -50,10 +50,18 @@ spec:
                 {{- end -}}
                 {{- toYaml .Values.storageScrubber.command | nindent 16 }}
               env:
+                {{- if .Values.storageScrubber.awsBucket }}
                 - name: BUCKET
                   value: {{ .Values.storageScrubber.awsBucket }}
+                {{- end }}
+                {{- if .Values.storageScrubber.awsRegion }}
                 - name: REGION
                   value: {{ .Values.storageScrubber.awsRegion }}
+                {{- end }}
+                {{- if .Values.storageScrubber.remoteStorageConfig }}
+                - name: REMOTE_STORAGE_CONFIG
+                  value: {{ toToml .Values.storageScrubber.remoteStorageConfig | nindent 20 }}
+                {{- end }}
                 {{- if .Values.settings }}
                 {{- with .Values.settings.sentryUrl }}
                 - name: SENTRY_DSN

--- a/charts/neon-storage-scrubber/values.yaml
+++ b/charts/neon-storage-scrubber/values.yaml
@@ -43,6 +43,8 @@ storageScrubber:
   awsRegion: ""
   # -- The AWS bucket for the pageserver storage
   awsBucket: ""
+  # -- The config object to connect to the remote storage (alternative to previous two vars)
+  remoteStorageConfig: {}
   # -- The timezone for the cron job
   timeZone: "Etc/UTC"
   # -- The schedule for the cron job -- By default runs every day at 6pm


### PR DESCRIPTION
Adds an object-typed `remoteStorageConfig` variable to `neon-storage-scrubber`.

Earlier PR: #88 
Part of https://github.com/neondatabase/cloud/issues/19963