### PR TITLE
storcon: change default CPU request 200m->1

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 
@@ -53,7 +53,7 @@ Kubernetes: `^1.18.x-x`
 | registerControlPlane.resources.requests.cpu | string | `"100m"` |  |
 | registerControlPlane.resources.requests.memory | string | `"128M"` |  |
 | resources.limits.memory | string | `"4Gi"` |  |
-| resources.requests.cpu | string | `"200m"` |  |
+| resources.requests.cpu | string | `"1"` |  |
 | resources.requests.memory | string | `"1Gi"` |  |
 | securityContext | object | `{}` | neon-storage-controller's containers Security Context |
 | service.annotations | object | `{}` | Annotations to add to the service |

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -107,7 +107,7 @@ resources:
   limits:
     memory: 4Gi
   requests:
-    cpu: 200m
+    cpu: "1"
     memory: 1Gi
 
 # -- Node labels for pod assignment.


### PR DESCRIPTION
We could configure this in the values.yaml used when deploying, but it seems like a sensible default: we know that the controller can require more CPU when doing scheduling across large numbers of tenants, and have seen suspicious container terminations that might result from CPU starvation.