### PR TITLE
storage-scrubber: fix up secret env var name in cmdline

### DIFF
--- a/charts/neon-storage-scrubber/Chart.yaml
+++ b/charts/neon-storage-scrubber/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-scrubber
 description: neon-storage-scrubber
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: "v0.1.0"
 sources:
   - https://github.com/neondatabase/neon/tree/main/storage_scrubber

--- a/charts/neon-storage-scrubber/README.md
+++ b/charts/neon-storage-scrubber/README.md
@@ -1,6 +1,6 @@
 # neon-storage-scrubber
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 neon-storage-scrubber
 

--- a/charts/neon-storage-scrubber/templates/cronjob.yaml
+++ b/charts/neon-storage-scrubber/templates/cronjob.yaml
@@ -44,7 +44,7 @@ spec:
                 - /usr/local/bin/storage_scrubber
                 {{- if .Values.storageScrubber.enableStorageControllerConnection }}
                 - "--controller-jwt"
-                - "$(STORAGE_CONTROLLER_JWT)"
+                - "$(STORAGE_CONTROLLER_JWT_TOKEN)"
                 - "--controller-api"
                 - {{ .Values.storageScrubber.storageControllerUrl | quote }}
                 {{- end -}}


### PR DESCRIPTION
Looking at `secrets.yaml`, the env var is `STORAGE_CONTROLLER_JWT_TOKEN` and not `STORAGE_CONTROLLER_JWT`.
The token reaches the pod and is correct, but the invocation is wrong.