### PR TITLE
storage-scrubber: add ability to set pod labels

### DIFF
--- a/charts/neon-storage-scrubber/Chart.yaml
+++ b/charts/neon-storage-scrubber/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-scrubber
 description: neon-storage-scrubber
 type: application
-version: 1.3.1
+version: 1.4.0
 appVersion: "v0.1.0"
 sources:
   - https://github.com/neondatabase/neon/tree/main/storage_scrubber

--- a/charts/neon-storage-scrubber/README.md
+++ b/charts/neon-storage-scrubber/README.md
@@ -1,6 +1,6 @@
 # neon-storage-scrubber
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 neon-storage-scrubber
 
@@ -32,6 +32,7 @@ $ helm install neon-storage-scrubber neondatabase/neon-storage-scrubber
 | nameOverride | string | `""` | String to partially override neon-storage-scrubber.fullname template (will maintain the release name) |
 | nodeSelector | object | `{}` | Node labels for pod assignment. |
 | podAnnotations | object | `{}` | Annotations for neon-storage-scrubber pods |
+| podLabels | object | `{}` | Labels for neon-storage-scrubber pods |
 | podSecurityContext | object | `{}` | neon-storage-scrubber's pods Security Context |
 | resources.limits.cpu | string | `"200m"` |  |
 | resources.limits.memory | string | `"2Gi"` |  |

--- a/charts/neon-storage-scrubber/templates/cronjob.yaml
+++ b/charts/neon-storage-scrubber/templates/cronjob.yaml
@@ -25,6 +25,9 @@ spec:
           {{- end }}
           labels:
             {{- include "neon-storage-scrubber.selectorLabels" . | nindent 12 }}
+          {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         spec:
           restartPolicy: Never # Do not restart if the task fails
           {{- with .Values.imagePullSecrets }}

--- a/charts/neon-storage-scrubber/values.yaml
+++ b/charts/neon-storage-scrubber/values.yaml
@@ -65,6 +65,9 @@ storageScrubber:
 # -- Annotations for neon-storage-scrubber pods
 podAnnotations: {}
 
+# -- Labels for neon-storage-scrubber pods
+podLabels: {}
+
 # -- neon-storage-scrubber's pods Security Context
 podSecurityContext:
   {}


### PR DESCRIPTION
Required for setting labels on pods without modifying other labels.
