### PR TITLE
chore(storcon): Set enable flag on NLB based service

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.2.1
+version: 1.3.0
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 
@@ -34,6 +34,13 @@ Kubernetes: `^1.18.x-x`
 | image.repository | string | `"neondatabase/neon"` | Neondatabase image repository |
 | image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Specify docker-registry secret names as an array |
+| ingress.annotations | object | `{}` | Additional annotations for Ingress resource. |
+| ingress.className | string | `""` | Ingress class for controller |
+| ingress.enabled | bool | `false` | Enable ingress controller resource. |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
+| ingress.hosts[0].paths[0].protocol | string | `"TCP"` |  |
 | metrics.enabled | bool | `false` | Enable prometheus metrcis autodiscovery |
 | metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resource |
 | metrics.serviceMonitor.interval | string | `"10s"` | Interval in which prometheus scrapes |
@@ -62,6 +69,7 @@ Kubernetes: `^1.18.x-x`
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| serviceNLB | bool | `true` |  |
 | settings.chaosInterval | string | `""` | Chaos testing interval |
 | settings.computeHookUrl | string | `""` |  |
 | settings.controlPlaneJwtToken | string | `""` |  |

--- a/charts/neon-storage-controller/templates/_helpers.tpl
+++ b/charts/neon-storage-controller/templates/_helpers.tpl
@@ -60,3 +60,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns service name
+This will be use only for internal purpose e.g. ingress connecting to service
+*/}}
+{{- define "neon-storage-controller.serviceName" -}}
+{{- printf "%s-svc" (include "neon-storage-controller.fullname" .) | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/charts/neon-storage-controller/templates/ingress.yaml
+++ b/charts/neon-storage-controller/templates/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "neon-storage-controller.fullname" . }}
+  labels:
+    {{- include "neon-storage-controller.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "neon-storage-controller.serviceName" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+

--- a/charts/neon-storage-controller/templates/service.yaml
+++ b/charts/neon-storage-controller/templates/service.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.serviceNLB -}}
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +19,4 @@ spec:
       name: controller
   selector:
     {{- include "neon-storage-controller.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/neon-storage-controller/templates/service.yaml
+++ b/charts/neon-storage-controller/templates/service.yaml
@@ -20,3 +20,18 @@ spec:
   selector:
     {{- include "neon-storage-controller.selectorLabels" . | nindent 4 }}
 {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "neon-storage-controller.serviceName" . }}
+  labels:
+    {{- include "neon-storage-controller.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: controller
+      protocol: TCP
+      name: controller
+  selector:
+    {{- include "neon-storage-controller.selectorLabels" . | nindent 4 }}

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -103,6 +103,10 @@ service:
   # service.port -- controller listen port
   port: 50051
 
+# Temporary set "serviceNLB" to keep existing Service with Type LoadBalancer
+# After migration we can set this to false to remove NLB
+serviceNLB: true
+
 resources:
   limits:
     memory: 4Gi

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -107,6 +107,21 @@ service:
 # After migration we can set this to false to remove NLB
 serviceNLB: true
 
+ingress:
+  # ingress.enabled -- Enable ingress controller resource.
+  enabled: false
+  # ingress.className -- Ingress class for controller
+  className: ""
+  # ingress.annotations -- Additional annotations for Ingress resource.
+  annotations: {}
+    # external-dns.alpha.kubernetes.io/hostname: chart-example.local
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          # https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+          pathType: Prefix
+          protocol: TCP
 resources:
   limits:
     memory: 4Gi


### PR DESCRIPTION
## Description

We will migrate the storage controller from NLB to the ingress controller. 

Our plan for testing on staging:

- PR-1: Add ingress support to Helm chart  (This PR)
- PR-2: Deploy changes to staging (new values):
  - Renaming DNS to `storage-controller-<dns>` --> `storage-controller-old-<dns>`   
  - New Service which points to storage controller pod (this is required for nginx ingress controller)
  - New Ingress rule with DNS `storage-controller-<dns>`
  - Assuming the above changes are applied
  - Clients will resolve to Ingress controller after TTL expires
- PR-3: Once everything works then, we can deprecate the old service NLB object i.e. `storage-controller-old-<dns>` by setting the value `serviceNLB: false`


Slack: https://neondb.slack.com/archives/C039YKBRZB4/p1734029656095099?thread_ts=1734001482.817909&cid=C039YKBRZB4 
Ref: https://github.com/neondatabase/cloud/issues/19921