### PR TITLE
storage controller: do not set LD_LIBRARY_PATH

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -76,8 +76,6 @@ spec:
             - {{ .Values.settings.longReconcileThreshold | quote }}
           {{- end }}
           env:
-            - name: LD_LIBRARY_PATH
-              value: "/usr/local/v16/lib"
             - name: RUST_LOG
               value: "INFO"
             - name: RUST_BACKTRACE


### PR DESCRIPTION
This was set to use the Neon-built postgres to avoid needing an extra vanilla postgres client binary in the container image.

However, using that build was problematic when it switched to using statically compiled openssl (which is unsafe when used from multi-threaded binaries), so let's use
the system libpq instead.

Depends on https://github.com/neondatabase/neon/pull/10269 to provide the system docker package.