### PR TITLE
storage-controller registration: start with active=true

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.3.1
+version: 1.4.0
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 

--- a/charts/neon-storage-controller/scripts/register-storage-controller.py
+++ b/charts/neon-storage-controller/scripts/register-storage-controller.py
@@ -34,7 +34,7 @@ PAYLOAD = dict(
     availability_zone_id=ZONE,
     instance_type="",
     register_reason="Storage Controller Virtual Pageserver",
-    active=False,
+    active=True,
     is_storage_controller=True,
     # Hardcoded because nothing is checking this version.
     version=0,


### PR DESCRIPTION
There isn't a good reason for why storage controller should be registered with an active state of
false. Registering them with `active=true` saves a manual action later.

https://neondb.slack.com/archives/C033RQ5SPDH/p1738770565943569
