### PR TITLE
storage-controller: remove unused vars, cleanup documentation

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 
@@ -52,7 +52,6 @@ Kubernetes: `^1.18.x-x`
 | podAnnotations | object | `{}` | Annotations for neon-storage-controller pods |
 | podLabels | object | `{}` | Additional labels for neon-storage-controller pods |
 | podSecurityContext | object | `{}` | neon-storage-controller's pods Security Context |
-| registerControlPlane.apiKey | string | `""` |  |
 | registerControlPlane.controlPlaneJwtToken | string | `""` |  |
 | registerControlPlane.enable | bool | `false` |  |
 | registerControlPlane.resources.limits.cpu | string | `"100m"` |  |

--- a/charts/neon-storage-controller/scripts/register-storage-controller.py
+++ b/charts/neon-storage-controller/scripts/register-storage-controller.py
@@ -21,7 +21,6 @@ URL_PATH = "management/api/v2/pageservers"
 ADMIN_URL_PATH = f"regions/{REGION}/api/v1/admin/pageservers"
 
 CPLANE_MANAGEMENT_URL = f"{os.environ['CPLANE_URL'].strip('/')}/{URL_PATH}"
-CONSOLE_URL = f"{os.environ['CONSOLE_URL']}/{ADMIN_URL_PATH}"
 
 PAYLOAD = dict(
     host=HOST,
@@ -95,7 +94,6 @@ if __name__ == "__main__":
         json.dumps(
             dict(
                 CPLANE_MANAGEMENT_URL=CPLANE_MANAGEMENT_URL,
-                CONSOLE_URL=CONSOLE_URL,
                 **PAYLOAD,
             ),
             indent=4,

--- a/charts/neon-storage-controller/templates/post-install-job.yaml
+++ b/charts/neon-storage-controller/templates/post-install-job.yaml
@@ -60,8 +60,6 @@ spec:
           value: {{ .Values.registerControlPlane.port | quote }}
         - name: CPLANE_URL
           value: {{ .Values.registerControlPlane.cplane_url | quote }}
-        - name: CONSOLE_URL
-          value: {{ .Values.registerControlPlane.console_url | quote }}
         - name: REGION_ID
           value: {{ .Values.registerControlPlane.region_id | quote }}
         envFrom:

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -52,10 +52,7 @@ registerControlPlane:
   enable: false
   # region_id: "<region-id>"
   controlPlaneJwtToken: ""
-  # Console API key to list existing pageserver to get version
-  apiKey: ""
   # cplane_url: "<control-plane-url>"
-  # console_url: ""
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
We don't need to know the console URL or API keys since
https://github.com/neondatabase/helm-charts/pull/113, however, there's still some cleanup left.

The `CONSOLE_URL` variable is not used in `register-storage-controller.py` (except for logging), so
we can delete it and don't need to set it in the registration job either.

Similarly, API keys are not needed, remove references in values files and documentation.

Bump to version to 1.5.1, as this should be consired a bugfix to perform some belated cleanup.
