### PR TITLE
Add safekeeper JWT token to storcon helm chart

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.6.0
+version: 1.7.0
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 
@@ -77,6 +77,7 @@ Kubernetes: `^1.18.x-x`
 | settings.longReconcileThreshold | string | `"30min"` | If a reconciliation takes longer than this, bump an alerting metric |
 | settings.peerJwtToken | string | `""` | JWT token for authentication with other storage controller instances |
 | settings.publicKey | string | `""` |  |
+| settings.safekeeperJwtToken | string | `""` |  JWT token for authentication with safekeepers |
 | settings.sentryEnvironment | string | `"development"` | "development" or "production". It will be visible in sentry in order to filter issues |
 | settings.sentryUrl | string | `""` | url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in storage-controller |
 | settings.splitThreshold | string | `""` | Size threshold in bytes for automatically sharding a tenant.  Omit to disable auto-sharding (default) |

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -77,7 +77,7 @@ Kubernetes: `^1.18.x-x`
 | settings.longReconcileThreshold | string | `"30min"` | If a reconciliation takes longer than this, bump an alerting metric |
 | settings.peerJwtToken | string | `""` | JWT token for authentication with other storage controller instances |
 | settings.publicKey | string | `""` |  |
-| settings.safekeeperJwtToken | string | `""` |  JWT token for authentication with safekeepers |
+| settings.safekeeperJwtToken | string | `""` | JWT token for authentication with safekeepers |
 | settings.sentryEnvironment | string | `"development"` | "development" or "production". It will be visible in sentry in order to filter issues |
 | settings.sentryUrl | string | `""` | url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in storage-controller |
 | settings.splitThreshold | string | `""` | Size threshold in bytes for automatically sharding a tenant.  Omit to disable auto-sharding (default) |

--- a/charts/neon-storage-controller/templates/secrets.yaml
+++ b/charts/neon-storage-controller/templates/secrets.yaml
@@ -8,5 +8,6 @@ type: Opaque
 data:
   DATABASE_URL: {{ .Values.settings.databaseUrl | b64enc | quote }}
   CONTROL_PLANE_JWT_TOKEN: {{ .Values.settings.controlPlaneJwtToken | b64enc | quote }}
-  PAGESERVER_JWT_TOKEN: {{ .Values.settings.jwtToken| b64enc | quote }}
+  PAGESERVER_JWT_TOKEN: {{ .Values.settings.jwtToken | b64enc | quote }}
+  SAFEKEEPER_JWT_TOKEN: {{ .Values.settings.safekeeperJwtToken | b64enc | quote }}
   PEER_JWT_TOKEN: {{ .Values.settings.peerJwtToken | b64enc | quote }}

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -28,6 +28,8 @@ settings:
   databaseUrl: ""
   # JWT token for authentication with pageservers
   jwtToken: ""
+  # JWT token for authentication with safekeepers
+  safekeeperJwtToken: ""
   # -- JWT token for authentication with other storage controller instances
   peerJwtToken: ""
   # public key for authenticating incoming HTTP requests

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -28,7 +28,7 @@ settings:
   databaseUrl: ""
   # JWT token for authentication with pageservers
   jwtToken: ""
-  # JWT token for authentication with safekeepers
+  # -- JWT token for authentication with safekeepers
   safekeeperJwtToken: ""
   # -- JWT token for authentication with other storage controller instances
   peerJwtToken: ""


### PR DESCRIPTION
Adds a safekeeper specific JWT token config variable to the helm chart of the storage controller.

Neon PR: https://github.com/neondatabase/neon/pull/10905
Part of https://github.com/neondatabase/cloud/issues/24727