### PR TITLE
neon-storage-controller: add new split settings

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.8.0
+version: 1.9.0
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -74,14 +74,17 @@ Kubernetes: `^1.18.x-x`
 | settings.controlPlaneJwtToken | string | `""` |  |
 | settings.controlPlaneUrl | string | `""` | Base URL for control plane API endpoints (e.g., https://control-plane.example.com/storage/api/v1/) |
 | settings.databaseUrl | string | `""` |  |
+| settings.initialSplitShards | string | `""` | Number of shards to use for initial tenant splits. |
+| settings.initialSplitThreshold | string | `""` | Size threshold in bytes for initial tenant splits. |
 | settings.jwtToken | string | `""` |  |
 | settings.longReconcileThreshold | string | `"30min"` | If a reconciliation takes longer than this, bump an alerting metric |
+| settings.maxSplitShards | string | `""` | Maximum number of shards for autosplits. |
 | settings.peerJwtToken | string | `""` | JWT token for authentication with other storage controller instances |
 | settings.publicKey | string | `""` |  |
 | settings.safekeeperJwtToken | string | `""` | JWT token for authentication with safekeepers |
 | settings.sentryEnvironment | string | `"development"` | "development" or "production". It will be visible in sentry in order to filter issues |
 | settings.sentryUrl | string | `""` | url (will be converted into `SENTRY_DSN` environment variable) used by sentry to collect error/panic events in storage-controller |
-| settings.splitThreshold | string | `""` | Size threshold in bytes for automatically sharding a tenant.  Omit to disable auto-sharding (default) |
+| settings.splitThreshold | string | `""` | Shard size threshold in bytes for automatically splitting shards.  Omit to disable auto-sharding (default) |
 | settings.startAsCandidate | bool | `false` | When set to True, restart the service gracefully |
 | tolerations | list | `[]` | Tolerations for pod assignment. |
 

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -61,9 +61,21 @@ spec:
             - --control-plane-url
             - {{ .Values.settings.controlPlaneUrl | quote }}
           {{- end }}
+          {{- if .Values.settings.initialSplitThreshold }}
+            - --initial-split-threshold
+            - {{ .Values.settings.initialSplitThreshold | quote }}
+          {{- end }}
+          {{- if .Values.settings.initialSplitShards }}
+            - --initial-split-shards
+            - {{ .Values.settings.initialSplitShards | quote }}
+          {{- end }}
           {{- if .Values.settings.splitThreshold }}
             - --split-threshold
             - {{ .Values.settings.splitThreshold | quote }}
+          {{- end }}
+          {{- if .Values.settings.maxSplitShards }}
+            - --max-split-shards
+            - {{ .Values.settings.maxSplitShards | quote }}
           {{- end }}
           {{- if .Values.settings.chaosInterval }}
             - --chaos-interval

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -40,8 +40,14 @@ settings:
   controlPlaneUrl: ""
   # URL for compute notifications
   computeHookUrl: ""
-  # settings.splitThreshold -- Size threshold in bytes for automatically sharding a tenant.  Omit to disable auto-sharding (default)
+  # settings.initialSplitThreshold -- Size threshold in bytes for initial tenant splits.
+  initialSplitThreshold: ""
+  # settings.initialSplitShards -- Number of shards to use for initial tenant splits.
+  initialSplitShards: ""
+  # settings.splitThreshold -- Shard size threshold in bytes for automatically splitting shards.  Omit to disable auto-sharding (default)
   splitThreshold: ""
+  # settings.maxSplitShards -- Maximum number of shards for autosplits.
+  maxSplitShards: ""
   # -- Chaos testing for tenant migration interval
   chaosInterval: ""
   # -- Chaos testing for immediate exit crontab


### PR DESCRIPTION
This patch adds support for the new split settings from https://github.com/neondatabase/neon/pull/11122:

* `initial_split_threshold`
* `initial_split_shards`
* `max_split_shards`