### PR TITLE
lint: bump k3s

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Create k3d cluster
         uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.25
+          version: v1.32
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
v1.25 is no longer available, causing CI failures.