### PR TITLE
add settings for root ca configmap for proxy

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.11.0
+version: 1.12.0
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 
@@ -41,6 +41,7 @@ Kubernetes: `^1.18.x-x`
 | image.repository | string | `"neondatabase/neon"` | Neondatabase image repository |
 | image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Specify docker-registry secret names as an array |
+| internalCa | string | `nil` | The root certificate(s) that neon-proxy should use to validate compute TLS certificates. |
 | metrics.enabled | bool | `false` | Enable prometheus metrcis autodiscovery |
 | metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resource |
 | metrics.serviceMonitor.interval | string | `"10s"` | Interval in which prometheus scrapes |

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -232,12 +232,12 @@ spec:
             - name: AWS_SECRET_ACCESS_KEY
               value: {{ . }}
             {{- end }}
-            {{- if .Values.settings.internalCA }}
+            {{- if .Values.internalCa }}
             - name: NEON_INTERNAL_CA_FILE
               value: /root_cert/neon_root_ca.crt
             {{- end }}
           {{- end }}
-          {{- if or .Values.settings.domain .Values.settings.internalCA }}
+          {{- if or .Values.settings.domain .Values.internalCa }}
           volumeMounts:
             - mountPath: "/certs"
               name: certs
@@ -247,7 +247,7 @@ spec:
               name: {{ include "neon-proxy.certificate-name" . }}
               readOnly: true
             {{- end }}
-            {{- if .Values.settings.internalCA }}
+            {{- if .Values.internalCa }}
             - mountPath: "/root_cert"
               name: internal-ca
               readOnly: true
@@ -296,7 +296,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if or .Values.settings.domain .Values.settings.internalCA }}
+      {{- if or .Values.settings.domain .Values.internalCa }}
       volumes:
         - name: certs
           secret:
@@ -306,7 +306,7 @@ spec:
           secret:
             secretName: {{ include "neon-proxy.certificate-secret" . }}
         {{- end }}
-        {{- if .Values.settings.internalCA }}
+        {{- if .Values.internalCa }}
         - name: internal-ca
           configMap:
             name: {{ include "neon-proxy.fullname" . }}-internal-ca

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -232,8 +232,12 @@ spec:
             - name: AWS_SECRET_ACCESS_KEY
               value: {{ . }}
             {{- end }}
+            {{- if .Values.settings.internalCA }}
+            - name: NEON_INTERNAL_CA_FILE
+              value: /root_cert/neon_root_ca.crt
+            {{- end }}
           {{- end }}
-          {{- if .Values.settings.domain }}
+          {{- if or .Values.settings.domain .Values.settings.internalCA }}
           volumeMounts:
             - mountPath: "/certs"
               name: certs
@@ -241,6 +245,11 @@ spec:
             {{- range .Values.settings.extraDomains }}
             - mountPath: '/certs-extra/{{ include "neon-proxy.certificate-name" . }}'
               name: {{ include "neon-proxy.certificate-name" . }}
+              readOnly: true
+            {{- end }}
+            {{- if .Values.settings.internalCA }}
+            - mountPath: "/root_cert"
+              name: internal-ca
               readOnly: true
             {{- end }}
           {{- end }}
@@ -287,7 +296,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if .Values.settings.domain }}
+      {{- if or .Values.settings.domain .Values.settings.internalCA }}
       volumes:
         - name: certs
           secret:
@@ -296,6 +305,11 @@ spec:
         - name: {{ include "neon-proxy.certificate-name" . }}
           secret:
             secretName: {{ include "neon-proxy.certificate-secret" . }}
+        {{- end }}
+        {{- if .Values.settings.internalCA }}
+        - name: internal-ca
+          configMap:
+            name: {{ include "neon-proxy.fullname" . }}-internal-ca
         {{- end }}
       {{ end }}
       {{- with .Values.nodeSelector }}

--- a/charts/neon-proxy/templates/root_ca.yaml
+++ b/charts/neon-proxy/templates/root_ca.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.settings.internalCA }}
+{{- if .Values.internalCa }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "neon-proxy.fullname" . }}-internal-ca
 data:
-  neon_root_ca.crt: {{ .Values.settings.internalCA }}
+  neon_root_ca.crt: {{ .Values.internalCa }}
 {{- end }}

--- a/charts/neon-proxy/templates/root_ca.yaml
+++ b/charts/neon-proxy/templates/root_ca.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.settings.internalCA }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "neon-proxy.fullname" . }}-internal-ca
+data:
+  neon_root_ca.crt: {{ .Values.settings.internalCA }}
+{{- end }}

--- a/charts/neon-proxy/values.yaml
+++ b/charts/neon-proxy/values.yaml
@@ -22,6 +22,9 @@ image:
 # -- Specify docker-registry secret names as an array
 imagePullSecrets: []
 
+# -- (string) The root certificate(s) that neon-proxy should use to validate compute TLS certificates.
+internalCa: null
+
 # -- String to partially override neon-proxy.fullname template (will maintain the release name)
 nameOverride: ""
 # -- String to fully override neon-proxy.fullname template


### PR DESCRIPTION
Proxy requires the root certificate of our internal CA in order to connect to computes via TLS.