### PR TITLE
neon-proxy: output root certificate as block and indent

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.12.0
+version: 1.12.1
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.12.1](https://img.shields.io/badge/Version-1.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 

--- a/charts/neon-proxy/templates/root_ca.yaml
+++ b/charts/neon-proxy/templates/root_ca.yaml
@@ -4,5 +4,6 @@ kind: ConfigMap
 metadata:
   name: {{ include "neon-proxy.fullname" . }}-internal-ca
 data:
-  neon_root_ca.crt: {{ .Values.internalCa }}
+  neon_root_ca.crt: |
+{{- .Values.internalCa | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
We need to output the root certificate as a block and indent accordingly in order to avoid YAML
parsing errors.
