### PR TITLE
impr: proxy restarts when config changes

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.12.1
+version: 1.12.2
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.12.1](https://img.shields.io/badge/Version-1.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.12.2](https://img.shields.io/badge/Version-1.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         checksum/config: |
+          # restart the binary on settings change
           {{ .Values.settings | toJson | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -14,7 +14,8 @@ spec:
   template:
     metadata:
       annotations:
-        {{ .Values.settings | toJson | sha256sum }}
+        checksum/config: |
+          {{ .Values.settings | toJson | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -13,8 +13,9 @@ spec:
       {{- include "neon-proxy.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{ .Values.settings | toJson | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Since proxy settings are delivered with ENV variables, the binary must restart when the `.Values.settings` change.
