### PR TITLE
proxy: Don't try to mount the SNI router cert when not configured

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.13.0
+version: 1.13.1
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.13.0](https://img.shields.io/badge/Version-1.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.13.1](https://img.shields.io/badge/Version-1.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -252,14 +252,16 @@ spec:
               value: /root_cert/neon_root_ca.crt
             {{- end }}
           {{- end }}
-          {{- if or .Values.settings.domain .Values.internalCa }}
+          {{- if or .Values.settings.domain .Values.pgSniRouter.domain .Values.internalCa }}
           volumeMounts:
             - mountPath: "/certs"
               name: certs
               readOnly: true
+            {{- if .Values.pgSniRouter.domain }}
             - mountPath: "/certs-sni-router"
               name: certs-sni-router
               readOnly: true
+            {{- end }}
             {{- range .Values.settings.extraDomains }}
             - mountPath: '/certs-extra/{{ include "neon-proxy.certificate-name" . }}'
               name: {{ include "neon-proxy.certificate-name" . }}


### PR DESCRIPTION
Fix the proxy chart for instances that don't start the SNI router by conditionally mounting the relevant certificate.