### PR TITLE
Use explicit resource request for broker service

### DIFF
--- a/charts/neon-storage-broker/Chart.yaml
+++ b/charts/neon-storage-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-broker
 description: Neon storage broker
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-broker/README.md
+++ b/charts/neon-storage-broker/README.md
@@ -1,6 +1,6 @@
 # neon-storage-broker
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage broker
 

--- a/charts/neon-storage-broker/README.md
+++ b/charts/neon-storage-broker/README.md
@@ -53,7 +53,9 @@ Kubernetes: `^1.18.x-x`
 | podLabels | object | `{}` | Additional labels for neon-storage-broker pods |
 | podSecurityContext | object | `{}` | neon-storage-broker's pods Security Context |
 | priorityClassName | string | `""` | Pod priority class |
-| resources | object | `{}` |  |
+| resources.limits.memory | string | `"8Gi"` |  |
+| resources.requests.cpu | string | `"1"` |  |
+| resources.requests.memory | string | `"2Gi"` |  |
 | securityContext | object | `{}` | neon-storage-broker's containers Security Context |
 | service.annotations | object | `{}` | Annotations to add to the service |
 | service.port | int | `50051` | broker listen port |

--- a/charts/neon-storage-broker/values.yaml
+++ b/charts/neon-storage-broker/values.yaml
@@ -64,21 +64,12 @@ service:
   # service.port -- broker listen port
   port: 50051
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  #
-  # resources.limits -- The resources limits for the container
-  # resources.requests The requested resources for the container
-  #
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    memory: 8Gi
+  requests:
+    cpu: "1"
+    memory: 2Gi
 
 # -- Node labels for pod assignment.
 nodeSelector: {}


### PR DESCRIPTION
We've seen the broker OOM in prod because QoS for it is [best effort](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#besteffort).
Let's set explicit limits to deter that.

Note that in order to get this out we need to restart the service. Doing it live is [a v1.33 feature](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/). Restarting broker is disruptive, so let's figure that out separately.

Some more context: https://neondb.slack.com/archives/C033RQ5SPDH/p1747932577771809?thread_ts=1747927318.201659&cid=C033RQ5SPDH