### PR TITLE
storcon: add `maxOfflineInterval`, `heartbeatInterval`, and `maxWarmingUpInterval`

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.11.0
+version: 1.12.0
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -74,12 +74,14 @@ Kubernetes: `^1.18.x-x`
 | settings.controlPlaneJwtToken | string | `""` |  |
 | settings.controlPlaneUrl | string | `""` | Base URL for control plane API endpoints (e.g., https://control-plane.example.com/storage/api/v1/) |
 | settings.databaseUrl | string | `""` |  |
+| settings.heartbeatInterval | string | `""` | Period with which to send heartbeats to registered nodes. |
 | settings.initialSplitShards | string | `""` | Number of shards to use for initial tenant splits. |
 | settings.initialSplitThreshold | string | `""` | Size threshold in bytes for initial tenant splits. |
 | settings.jwtToken | string | `""` |  |
 | settings.longReconcileThreshold | string | `"30min"` | If a reconciliation takes longer than this, bump an alerting metric |
 | settings.maxOfflineInterval | string | `""` | Grace period before marking unresponsive pageserver offline. |
 | settings.maxSplitShards | string | `""` | Maximum number of shards for autosplits. |
+| settings.maxWarmingUpInterval | string | `""` | Extended grace period within which pageserver may not respond to heartbeats. Kicks in after the node has been drained for restart and/or upon handling the re-attach request from a node. |
 | settings.peerJwtToken | string | `""` | JWT token for authentication with other storage controller instances |
 | settings.publicKey | string | `""` |  |
 | settings.safekeeperJwtToken | string | `""` | JWT token for authentication with safekeepers |

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -78,7 +78,7 @@ Kubernetes: `^1.18.x-x`
 | settings.initialSplitThreshold | string | `""` | Size threshold in bytes for initial tenant splits. |
 | settings.jwtToken | string | `""` |  |
 | settings.longReconcileThreshold | string | `"30min"` | If a reconciliation takes longer than this, bump an alerting metric |
-| settings.maxOfflinePeriod | string | `""` | Grace period before marking unresponsive pageserver offline. |
+| settings.maxOfflineInterval | string | `""` | Grace period before marking unresponsive pageserver offline. |
 | settings.maxSplitShards | string | `""` | Maximum number of shards for autosplits. |
 | settings.peerJwtToken | string | `""` | JWT token for authentication with other storage controller instances |
 | settings.publicKey | string | `""` |  |

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 
@@ -78,6 +78,7 @@ Kubernetes: `^1.18.x-x`
 | settings.initialSplitThreshold | string | `""` | Size threshold in bytes for initial tenant splits. |
 | settings.jwtToken | string | `""` |  |
 | settings.longReconcileThreshold | string | `"30min"` | If a reconciliation takes longer than this, bump an alerting metric |
+| settings.maxOfflinePeriod | string | `""` | Grace period before marking unresponsive pageserver offline. |
 | settings.maxSplitShards | string | `""` | Maximum number of shards for autosplits. |
 | settings.peerJwtToken | string | `""` | JWT token for authentication with other storage controller instances |
 | settings.publicKey | string | `""` |  |

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -58,9 +58,17 @@ spec:
             - --control-plane-url
             - {{ .Values.settings.controlPlaneUrl | quote }}
           {{- end }}
-          {{- if .Values.settings.maxOfflineInterval}}
+          {{- if .Values.settings.heartbeatInterval }}
+            - --heartbeat-interval
+            - {{ .Values.settings.heartbeatInterval | quote }}
+          {{- end }}
+          {{- if .Values.settings.maxOfflineInterval }}
             - --max-offline-interval
             - {{ .Values.settings.maxOfflineInterval | quote }}
+          {{- end }}
+          {{- if .Values.settings.maxWarmingUpInterval }}
+            - --max-warming-up-interval
+            - {{ .Values.settings.maxWarmingUpInterval | quote }}
           {{- end }}
           {{- if .Values.settings.initialSplitThreshold }}
             - --initial-split-threshold

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -58,9 +58,9 @@ spec:
             - --control-plane-url
             - {{ .Values.settings.controlPlaneUrl | quote }}
           {{- end }}
-          {{- if .Values.settings.maxOfflinePeriod }}
-            - --max-offline-period
-            - {{ .Values.settings.maxOfflinePeriod | quote }}
+          {{- if .Values.settings.maxOfflineInterval}}
+            - --max-offline-interval
+            - {{ .Values.settings.maxOfflineInterval | quote }}
           {{- end }}
           {{- if .Values.settings.initialSplitThreshold }}
             - --initial-split-threshold

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
             - --control-plane-url
             - {{ .Values.settings.controlPlaneUrl | quote }}
           {{- end }}
+          {{- if .Values.settings.maxOfflinePeriod }}
+            - --max-offline-period
+            - {{ .Values.settings.maxOfflinePeriod | quote }}
+          {{- end }}
           {{- if .Values.settings.initialSplitThreshold }}
             - --initial-split-threshold
             - {{ .Values.settings.initialSplitThreshold | quote }}

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -38,6 +38,8 @@ settings:
   controlPlaneJwtToken: ""
   # -- Base URL for control plane API endpoints (e.g., https://control-plane.example.com/storage/api/v1/)
   controlPlaneUrl: ""
+  # settings.maxOfflinePeriod -- Grace period before marking unresponsive pageserver offline.
+  maxOfflinePeriod: ""
   # settings.initialSplitThreshold -- Size threshold in bytes for initial tenant splits.
   initialSplitThreshold: ""
   # settings.initialSplitShards -- Number of shards to use for initial tenant splits.

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -38,8 +38,14 @@ settings:
   controlPlaneJwtToken: ""
   # -- Base URL for control plane API endpoints (e.g., https://control-plane.example.com/storage/api/v1/)
   controlPlaneUrl: ""
+  # settings.heartbeatInterval -- Period with which to send heartbeats to registered nodes.
+  heartbeatInterval: ""
   # settings.maxOfflineInterval -- Grace period before marking unresponsive pageserver offline.
   maxOfflineInterval: ""
+  # settings.maxWarmingUpInterval -- Extended grace period within which pageserver may not respond
+  # to heartbeats. Kicks in after the node has been drained for restart and/or upon handling the
+  # re-attach request from a node.
+  maxWarmingUpInterval: ""
   # settings.initialSplitThreshold -- Size threshold in bytes for initial tenant splits.
   initialSplitThreshold: ""
   # settings.initialSplitShards -- Number of shards to use for initial tenant splits.

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -38,8 +38,8 @@ settings:
   controlPlaneJwtToken: ""
   # -- Base URL for control plane API endpoints (e.g., https://control-plane.example.com/storage/api/v1/)
   controlPlaneUrl: ""
-  # settings.maxOfflinePeriod -- Grace period before marking unresponsive pageserver offline.
-  maxOfflinePeriod: ""
+  # settings.maxOfflineInterval -- Grace period before marking unresponsive pageserver offline.
+  maxOfflineInterval: ""
   # settings.initialSplitThreshold -- Size threshold in bytes for initial tenant splits.
   initialSplitThreshold: ""
   # settings.initialSplitShards -- Number of shards to use for initial tenant splits.


### PR DESCRIPTION
We'd like to reduce this for faster Pageserver failover times.

Adds `maxOfflineInterval`, `heartbeatInterval` and `maxWarmingUpInterval`, since we'll likely need to tune all three.

Touches https://github.com/neondatabase/cloud/issues/28852.
Touches https://github.com/neondatabase/neon/pull/12258.