### PR TITLE
remove deprecated proxy fields

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.13.3
+version: 1.14.0
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.13.3](https://img.shields.io/badge/Version-1.13.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 
@@ -73,15 +73,12 @@ Kubernetes: `^1.18.x-x`
 | serviceAccount.name | string | `""` |  |
 | settings.authBackend | string | `"link"` | auth method used (console|link|postgres) |
 | settings.authEndpoint | string | `""` | auth endpoint, e.g. "http://console.neon/authenticate_proxy_request/" |
-| settings.authRateLimits | string | `nil` |  |
-| settings.authRateLimitsEnabled | bool | `nil` | Whether to enable the authentication rate limiter |
 | settings.awsAccessKeyId | string | `""` | (string) AWS Access Key ID |
 | settings.awsRegion | string | `""` | (string) Aws region to retrieve credentials |
 | settings.awsSecretAccessKey | string | `""` | (string) AWS Secret Access Key |
 | settings.connectComputeLock | string | `""` | (string) Configures the locking of connect_compute per compute |
 | settings.controlplane_token | string | `""` | (string) JWT token to pass to control plane management API |
 | settings.domain | string | `""` | domain used in TLS cert for client postgres connections |
-| settings.endpointCacheConfig | string | `""` | (string) Config for cache for all valid endpoints |
 | settings.endpointRpsLimits | list | `[]` | (list) list of rate limiters for connection attempts over different time intervals |
 | settings.extraCmdFlags | list | `[]` | (list) additional arguments to proxy binary |
 | settings.extraDomains | list | `[]` | domains used in extra TLS certs for client postgres connections |
@@ -105,7 +102,8 @@ Kubernetes: `^1.18.x-x`
 | settings.redisAuthType | string | `"irsa"` | (string) What auth type to use for regional Redis client. "irsa" and "plain" are supported. "plain" means use URI from settings.redisNotifications. "irsa" means AWS IRSA. |
 | settings.redisClusterName | string | `"regional-control-plane-redis"` | (string) Redis cluster name, used in aws elasticache |
 | settings.redisHost | string | `""` | (string) Redis host for streaming connections (might be different from the notifications host) |
-| settings.redisNotifications | string | `""` | (url) Configures redis client |
+| settings.redisNotifications | string | `""` | (url) Configures redis plain client |
+| settings.redisPlain | string | `""` | (url) Configures redis plain client |
 | settings.redisPort | string | `""` | (string) Redis port for streaming connections |
 | settings.redisUserId | string | `"neon"` | (string) Redis user_id, used in aws elasticache |
 | settings.region | string | `""` | (string) Region this proxy service is deployed into |

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -128,12 +128,6 @@ spec:
             {{- range .Values.settings.wakeComputeLimits }}
             - --wake-compute-limit={{ . }}
             {{- end }}
-            {{- if .Values.settings.authRateLimitsEnabled }}
-            - --auth-rate-limit-enabled
-            {{- end }}
-            {{- range .Values.settings.authRateLimits }}
-            - --auth-rate-limit={{ . }}
-            {{- end }}
             {{- with .Values.settings.region }}
             - --region={{ . }}
             {{ end }}
@@ -166,8 +160,8 @@ spec:
             - --connect-compute-lock
             - {{ . | quote }}
             {{- end }}
-            {{- with .Values.settings.redisNotifications}}
-            - --redis-notifications
+            {{- with or .Values.settings.redisPlain .Values.settings.redisNotifications}}
+            - --redis-plain
             - {{ . }}
             {{- end }}
             {{- with .Values.settings.redisAuthType}}
@@ -182,9 +176,6 @@ spec:
             {{ end }}
             {{- with .Values.settings.metricBackupCollectionChunkSize }}
             - --metric-backup-collection-chunk-size={{ . }}
-            {{ end }}
-            {{- with .Values.settings.endpointCacheConfig }}
-            - --endpoint-cache-config={{ . }}
             {{ end }}
             {{- with .Values.settings.redisHost }}
             - --redis-host={{ . }}

--- a/charts/neon-proxy/values.yaml
+++ b/charts/neon-proxy/values.yaml
@@ -68,8 +68,10 @@ settings:
   wakeComputeLock: "permits=0"
   # settings.connectComputeLock -- (string) Configures the locking of connect_compute per compute
   connectComputeLock: ""
-  # settings.redisNotifications -- (url) Configures redis client
+  # settings.redisNotifications -- (url) Configures redis plain client
   redisNotifications: ""
+  # settings.redisPlain -- (url) Configures redis plain client
+  redisPlain: ""
   # settings.redisAuthType -- (string) What auth type to use for regional Redis client. "irsa" and "plain" are supported. "plain" means use URI from settings.redisNotifications. "irsa" means AWS IRSA.
   redisAuthType: "irsa"
   # settings.sqlOverHttpMaxRequestSizeBytes -- (string) maximum sql-over-http request payload size in bytes
@@ -84,10 +86,6 @@ settings:
   endpointRpsLimits: []
   # settings.wakeComputeLimits -- (list) list of rate limiters for wake_compute over different time intervals
   wakeComputeLimits: []
-  # settings.authRateLimitsEnabled -- (bool) Whether to enable the authentication rate limiter
-  authRateLimitsEnabled: null
-  # settings.authRateLimit -- (list) list of rate limiters over different time intervals for authentication hash iterations per IP,EP
-  authRateLimits: null
   # settings.parquetUploadRemoteStorage -- (string) Storage location to upload the parquet files to.
   parquetUploadRemoteStorage: ""
   # settings.parquetUploadDisconnectEventsRemoteStorage -- (string) Storage location to upload the parquet files with disconnect events to.
@@ -114,8 +112,6 @@ settings:
   metricBackupCollectionInterval: "10m"
   # settings.metricBackupCollectionChunkSize -- (string) How large each chunk of the metric backup files should be in bytes
   metricBackupCollectionChunkSize: "4194304"
-  # settings.endpointCacheConfig -- (string) Config for cache for all valid endpoints
-  endpointCacheConfig: ""
   # settings.redisHost -- (string) Redis host for streaming connections (might be different from the notifications host)
   redisHost: ""
   # settings.redisPort -- (string) Redis port for streaming connections


### PR DESCRIPTION
the `authRateLimitsEnabled` and `authRateLimits` flags and functionality have now been removed.

`endpointCacheConfig` functionality has been removed.

`redisNotifications` has been renamed to `redisPlain` internally to represent that it's tied to the `redisAuthType: "plain"` setting.