### PR TITLE
proxy: Add NEON_MOTD greetings again

### DIFF
--- a/charts/neon-proxy/Chart.yaml
+++ b/charts/neon-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-proxy
 description: Neon Proxy
 type: application
-version: 1.13.5
+version: 1.13.6
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-proxy/README.md
+++ b/charts/neon-proxy/README.md
@@ -1,6 +1,6 @@
 # neon-proxy
 
-![Version: 1.13.5](https://img.shields.io/badge/Version-1.13.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.13.6](https://img.shields.io/badge/Version-1.13.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon Proxy
 
@@ -82,6 +82,7 @@ Kubernetes: `^1.18.x-x`
 | settings.consoleJwtPublicKey | string | `""` | (string) Public key for console JWT verification |
 | settings.controlplane_token | string | `""` | (string) JWT token to pass to control plane management API |
 | settings.domain | string | `""` | domain used in TLS cert for client postgres connections |
+| settings.enable_neonMotd | bool | `false` |  |
 | settings.endpointCacheConfig | string | `""` | (string) Config for cache for all valid endpoints |
 | settings.endpointRpsLimits | list | `[]` | (list) list of rate limiters for connection attempts over different time intervals |
 | settings.extraCmdFlags | list | `[]` | (list) additional arguments to proxy binary |

--- a/charts/neon-proxy/templates/deployment.yaml
+++ b/charts/neon-proxy/templates/deployment.yaml
@@ -255,6 +255,10 @@ spec:
             - name: NEON_CONSOLE_JWT_PUBLIC_KEY
               value: {{ . | quote }}
             {{- end }}
+            {{- if .Values.settings.enable_neonMotd }}
+            - name: NEON_MOTD
+              value: "Welcome to Neon!"
+            {{- end }}
           {{- end }}
           {{- if or .Values.settings.domain .Values.pgSniRouter.domain .Values.internalCa }}
           volumeMounts:

--- a/charts/neon-proxy/values.yaml
+++ b/charts/neon-proxy/values.yaml
@@ -132,6 +132,8 @@ settings:
   extraCmdFlags: []
   # settings.consoleJwtPublicKey -- (string) Public key for console JWT verification
   consoleJwtPublicKey: ""
+  # settings.neonMotd -- (boolean) Do we need to show welcome message with session_id?
+  enable_neonMotd: false
 
 pgSniRouter:
   # pgSniRouter.destination -- append this domain zone to the transformed SNI hostname to get the destination address, e.g. "svc.cluster.local"


### PR DESCRIPTION
Add NEON_MOTD greetings for session_id reporting with flag to differentiate between dev and prod env to prevent e2e tests failures