### PR TITLE
use self-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - linux-ubuntu-latest

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -11,7 +11,9 @@ permissions:
 jobs:
   codespell:
     name: Codespell
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -4,7 +4,9 @@ on: pull_request
 
 jobs:
   lint-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -36,7 +38,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo 'changed=true' | tee -a "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -8,7 +8,9 @@ on: pull_request
 jobs:
   build:
     name: Lint Code Base
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,9 @@ jobs:
   release:
     permissions:
       contents: write  # for helm/chart-releaser-action to push chart release and create a release
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0


### PR DESCRIPTION
Use self-hosted runners in workflows.

Also fix job step output setting as it's flagged by `actionlint`.
