### PR TITLE
Add lbmManagementUrl and lbmStorageUrl to replace controlPlaneUrl

### DIFF
--- a/charts/neon-storage-controller/Chart.yaml
+++ b/charts/neon-storage-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: neon-storage-controller
 description: Neon storage controller
 type: application
-version: 1.15.2
+version: 1.16.0
 appVersion: "0.1.0"
 kubeVersion: "^1.18.x-x"
 home: https://neon.tech

--- a/charts/neon-storage-controller/README.md
+++ b/charts/neon-storage-controller/README.md
@@ -1,6 +1,6 @@
 # neon-storage-controller
 
-![Version: 1.15.2](https://img.shields.io/badge/Version-1.15.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
+![Version: 1.16.0](https://img.shields.io/badge/Version-1.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Lint and Test Charts](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/neondatabase/helm-charts/actions/workflows/lint-test.yaml)
 
 Neon storage controller
 
@@ -83,6 +83,8 @@ Kubernetes: `^1.18.x-x`
 | settings.initialSplitThreshold | string | `""` | Size threshold in bytes for initial tenant splits. |
 | settings.jwtToken | string | `""` |  |
 | settings.lazyDrainsFills | string | `""` | If true, use lazy attaches for node drains and fills. |
+| settings.lbmManagementUrl | string | `""` | Base URL for control plane management API (e.g., https://control-plane.example.com:1000/) |
+| settings.lbmStorageUrl | string | `""` | Base URL for control plane storage API (e.g., https://control-plane.example.com:1002/storage/api/v1/) |
 | settings.longReconcileThreshold | string | `"30min"` | If a reconciliation takes longer than this, bump an alerting metric |
 | settings.maxOfflineInterval | string | `""` | Grace period before marking unresponsive pageserver offline. |
 | settings.maxSplitShards | string | `""` | Maximum number of shards for autosplits. |

--- a/charts/neon-storage-controller/templates/deployment.yaml
+++ b/charts/neon-storage-controller/templates/deployment.yaml
@@ -58,6 +58,14 @@ spec:
             - --control-plane-url
             - {{ .Values.settings.controlPlaneUrl | quote }}
           {{- end }}
+          {{- if .Values.settings.lbmManagementUrl }}
+            - --lbm-management-url
+            - {{ .Values.settings.lbmManagementUrl | quote }}
+          {{- end }}
+          {{- if .Values.settings.lbmStorageUrl }}
+            - --lbm-storage-url
+            - {{ .Values.settings.lbmStoragetUrl | quote }}
+          {{- end }}
           {{- if .Values.settings.heartbeatInterval }}
             - --heartbeat-interval
             - {{ .Values.settings.heartbeatInterval | quote }}

--- a/charts/neon-storage-controller/values.yaml
+++ b/charts/neon-storage-controller/values.yaml
@@ -38,6 +38,10 @@ settings:
   controlPlaneJwtToken: ""
   # -- Base URL for control plane API endpoints (e.g., https://control-plane.example.com/storage/api/v1/)
   controlPlaneUrl: ""
+  # -- Base URL for control plane management API (e.g., https://control-plane.example.com:1000/)
+  lbmManagementUrl: ""
+  # -- Base URL for control plane storage API (e.g., https://control-plane.example.com:1002/storage/api/v1/)
+  lbmStorageUrl: ""
   # settings.heartbeatInterval -- Period with which to send heartbeats to registered nodes.
   heartbeatInterval: ""
   # settings.maxOfflineInterval -- Grace period before marking unresponsive pageserver offline.


### PR DESCRIPTION
As part of https://databricks.atlassian.net/browse/LKB-7371 , we replace `controlPlaneUrl` with two new parameters `lbmManagementUrl` and `lbmStorageUrl`.